### PR TITLE
fixed coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.6"
 
 install:
- - pip install pytest pytest-cov euclid3
+ - pip install pytest pytest-cov euclid3 coveralls
 
 script:
   - py.test --cov=. tests/


### PR DESCRIPTION
Noticed I had forgotten to pip install `coveralls` in the travis file which is why the badge wasn't updating. Fixed it now and seems to have updated on the [coveralls.io page](https://coveralls.io/builds/17876088). Will merge with master which should hopefully update the badge accordingly.