### PR TITLE
Several Fixes for Timestep Calculations

### DIFF
--- a/ladybug/wea.py
+++ b/ladybug/wea.py
@@ -78,16 +78,23 @@ class Wea(object):
                    diffuse_horizontal_radiation, timestep)
 
     @classmethod
-    def from_epw_file(cls, epwfile):
+    def from_epw_file(cls, epwfile, timestep=1):
         """Create a wea object using the solar radiation values in an epw file.
 
         Args:
             epwfile: Full path to epw weather file.
+            timestep: An optional integer to set the number of time steps per hour.
+                Default is 1 for one value per hour.
         """
         epw = EPW(epwfile)
-        return cls(epw.location,
-                   epw.direct_normal_radiation,
-                   epw.diffuse_horizontal_radiation)
+        direct_normal = epw.direct_normal_radiation
+        diffuse_horizontal = epw.diffuse_horizontal_radiation
+        if timestep is not 1:
+            direct_normal = direct_normal.interpolate_data(timestep, True)
+            diffuse_horizontal = diffuse_horizontal.interpolate_data(timestep, True)
+
+        return cls(epw.location, direct_normal, diffuse_horizontal,
+                   timestep)
 
     @classmethod
     def from_stat_file(cls, statfile, timestep=1):

--- a/tox.ini
+++ b/tox.ini
@@ -9,3 +9,5 @@ deps =
     pytest
     pytest-cov
     euclid3
+[flake8]
+	max-line-length = 89


### PR DESCRIPTION
The most controversial change here that requires @mostaphaRoudsari 's review is bullet point 3 below.

I spent a lot of time thinking about how we want to deal with the interpolation of values in the data collection (and whether they fall on the half hour or the hour).  At first, I tried doing the implementation we initially thought we would do, where I just check the data type in the header against a list of values that I know to be on the half hour instead of the hour (specifically, radiation and illuminance).  But, as I started to think about it more, I realized that all of the E+ and Radiance results that we want to turn into data collections would eventually have to be added to this list since all of them are better represented by the half-hour than the hour (and adding the hundreds of E+ outputs to this list is not practical).  So I considered doing it in reverse, where the data type in the header is checked against a list of types that I know to be on the hour.  But it seemed wrong that the default would be to interpret the data as being on the half-hour when all of the data in the collection had datetimes that were on the hour.  Ultimately, I  just thought that everything would be much simpler if this half_hour was just an attribute that can be assigned to the data collection.  This solves the issue of having two locations where the half_hour nature of the epw data types is being stored (both in the epw class and in the data collection class).  It also frees up the data collection to deal with both results from E+ and Radiance (which we know to be half-hourly) as well as actual weather data (which is almost always on the the hour unless it's EPW radiation or illuminance).

Still, I recognize that this is not the most initially obvious solution and so I want your review @mostaphaRoudsari .

To give a full summary of everything in this commit:
1) The tox.ini file has been edited such that it now abides by our rule of 89 characters per line
2) The methods for shifting epw data depending on whether the values occur on the hour or half-hour have been cleaned up and made more efficient.  I reasoned that simply using boolean value titled "half_hour" is better than a float "start_hour" since houlrly data only occurs on the half hour or the hour mark.
3) Possibly the most controversial of change is that I added a property to the data collection class to track whether values should be interpreted as falling on the half hour or the hour.  This was done in lieu of checking  the type of the data in the header with a list of half-hour data types to look out for.  I will explain why I think this property is necessary when I send the pull request.
4) I added an option to specify data as cumulative on the interpolate data method, which is critical for using this method with radiation since sometimes you want the average flux at a timestep while other times you want the amount of solar energy that fell over the course of the last timestep.
5) I edited the Wea.from_epw_file method to allow for the input of a timestep.