### PR TITLE
Switched to python2.7-alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:2.7-alpine
 MAINTAINER Ladybug Tools "info@ladybug.tools"
 
 WORKDIR /usr/local/lib/python2.7/site-packages


### PR DESCRIPTION
Noticed docker images were built on standard python2.7 image. If the alpine (tiny container os) version is used the size of the final container can be dramatically reduced (which is good when scaling containerised applications). Point in case below:
![image](https://user-images.githubusercontent.com/20436635/42646208-166e8b82-85f8-11e8-8412-7da3085ab87c.png)
It will also drastically reduce the honeybee docker image by default. I gave it a quick test and it can still install radiance no problem (will need to check if it can still run radiance properly but I see no reason why it couldn't).