### PR TITLE
Set Default IronPython Variable for Very Old Versions

### DIFF
--- a/ladybug/stat.py
+++ b/ladybug/stat.py
@@ -63,7 +63,7 @@ class Stat(object):
     def import_data(self):
         """Import data from a stat file.
         """
-        statwin = codecs.open(self.file_path, 'r', encoding='utf-8', errors='ignore')
+        statwin = codecs.open(self.file_path, 'r')
         try:
             line = statwin.readline()
             # import header with location
@@ -81,8 +81,8 @@ class Stat(object):
 
             source = self._header[6].strip().replace('Data Source -- ', '')
             station_id = self._header[8].strip().replace('WMO Station ', '')
-            coord_pattern = re.compile(r"{([NSEW])(\s*\d*) (\s*\d*)'}")
-            matches = coord_pattern.findall(self._header[3])
+            coord_pattern = re.compile(r"{([NSEW])(\s*\d*)deg(\s*\d*)'}")
+            matches = coord_pattern.findall(self._header[3].replace('\xb0', 'deg'))
             lat_sign = -1 if matches[0][0] == 'S' else 1
             latitude = lat_sign * (float(matches[0][1]) + (float(matches[0][2]) / 60))
             lon_sign = -1 if matches[1][0] == 'W' else 1

--- a/ladybug/stat.py
+++ b/ladybug/stat.py
@@ -64,6 +64,8 @@ class Stat(object):
     def import_data(self):
         """Import data from a stat file.
         """
+        # set default state to ironpython for very old ironpython (2.7.0)
+        iron_python = True
         try:
             iron_python = True if platform.python_implementation() == 'IronPython' \
                 else False

--- a/ladybug/stat.py
+++ b/ladybug/stat.py
@@ -63,7 +63,7 @@ class Stat(object):
     def import_data(self):
         """Import data from a stat file.
         """
-        statwin = codecs.open(self.file_path, 'r')
+        statwin = codecs.open(self.file_path, 'r', encoding='utf-8', errors='ignore')
         try:
             line = statwin.readline()
             # import header with location
@@ -81,8 +81,8 @@ class Stat(object):
 
             source = self._header[6].strip().replace('Data Source -- ', '')
             station_id = self._header[8].strip().replace('WMO Station ', '')
-            coord_pattern = re.compile(r"{([NSEW])(\s*\d*)deg(\s*\d*)'}")
-            matches = coord_pattern.findall(self._header[3].replace('\xb0', 'deg'))
+            coord_pattern = re.compile(r"{([NSEW])(\s*\d*) (\s*\d*)'}")
+            matches = coord_pattern.findall(self._header[3])
             lat_sign = -1 if matches[0][0] == 'S' else 1
             latitude = lat_sign * (float(matches[0][1]) + (float(matches[0][2]) / 60))
             lon_sign = -1 if matches[1][0] == 'W' else 1


### PR DESCRIPTION
The old version of IronPython that ships with Rhino 5 has some bugs in the platform module.  In this case, the inron_python variable does not get set at all.  To avoid this case, I set a default variable of iron_python to True before checking the platform module.