### PR TITLE
fix(CI): publish after bumping version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ after_success:
   - git config --global user.name "ladybugbot"
   - git config --global user.email "release@ladybug.tools"
   - pip install python-semantic-release
-  - semantic-release version
+  - semantic-release release


### PR DESCRIPTION
Didn't read through your modification properly @mostaphaRoudsari and didn't notice the fact you had the command to bump version but not the command to deploy. The deploy command bumps versions and pushes to PyPi + github releases.