### PR TITLE
fix(euclid3): enforce dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setuptools.setup(
     url="https://github.com/ladybug-tools/ladybug",
     packages=setuptools.find_packages(),
     install_requires=[
-        'euclid3'
+        'euclid3==0.1'
     ],
     classifiers=[
         "Programming Language :: Python :: 2.7",


### PR DESCRIPTION
Judging by the last deploy of euclid3 being 2014 I am not overly worried about breaking changes but this is a good habit to keep.

Should fix #80 