### PR TITLE
feat(DataType): added datatype to handle unit conversions, checks, etc.

### DIFF
--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -54,19 +54,19 @@ class DataCollection(object):
         return cls(input_data, Header.from_json(data['header']))
 
     @classmethod
-    def from_list(cls, lst, location=None, data_type=None, unit=None,
-                  analysis_period=None):
+    def from_list(cls, lst, data_type=None, unit=None,
+                  analysis_period=None, location=None):
         """Create a data collection from a list.
 
         lst items can be DataPoint or numerical values.
 
         Args:
             lst: A list of data.
-            location: location data as a ladybug Location or location string
-                (Default: unknown).
-            data_type: Type of data (e.g. Temperature) (Default: unknown).
+            data_type: Type of data (e.g. Temperature).
             unit: data_type unit (Default: unknown).
             analysis_period: A Ladybug analysis period (Defualt: None)
+            location: location data as a ladybug Location or location string
+                (Default: unknown).
         """
         header = Header(data_type=data_type, unit=unit,
                         analysis_period=analysis_period,
@@ -152,9 +152,21 @@ class DataCollection(object):
 
     def to_unit(self, unit):
         """Convert the DataCollection to the input unit"""
-        self._data, self._header.data_type.unit = \
-            self._header.data_type.to_unit(
+        self._data = self._header.data_type.to_unit(
                 self._data, unit, self._header.data_type.unit)
+        self._header.data_type.unit = unit
+
+    def to_ip(self):
+        """Convert the DataCollection to IP units"""
+        self._data, self._header.data_type.unit = \
+            self._header.data_type.to_ip(
+                self._data, self._header.data_type.unit)
+
+    def to_ip(self):
+        """Convert the DataCollection to SI units"""
+        self._data, self._header.data_type.unit = \
+            self._header.data_type.to_si(
+                self._data, self._header.data_type.unit)
 
     @staticmethod
     def average(data):

--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -68,7 +68,9 @@ class DataCollection(object):
             unit: data_type unit (Default: unknown).
             analysis_period: A Ladybug analysis period (Defualt: None)
         """
-        header = Header(location, data_type, unit, analysis_period)
+        header = Header(data_type=data_type, unit=unit,
+                        analysis_period=analysis_period,
+                        location=location)
         if analysis_period:
             return cls.from_data_and_datetimes(lst, analysis_period.datetimes, header)
         else:
@@ -147,6 +149,12 @@ class DataCollection(object):
     def duplicate(self):
         """Duplicate current data list."""
         return DataCollection(self.data, self.header)
+
+    def to_unit(self, unit):
+        """Convert the DataCollection to the input unit"""
+        self._data, self._header.data_type.unit = \
+            self._header.data_type.to_unit(
+                self._data, unit, self._header.data_type.unit)
 
     @staticmethod
     def average(data):

--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -150,23 +150,41 @@ class DataCollection(object):
         """Duplicate current data list."""
         return DataCollection(self.data, self.header)
 
-    def to_unit(self, unit):
+    def convert_to_unit(self, unit):
         """Convert the DataCollection to the input unit"""
         self._data = self._header.data_type.to_unit(
-                self._data, unit, self._header.data_type.unit)
-        self._header.data_type.unit = unit
+                self._data, unit, self._header.unit)
+        self._header._unit = unit
 
-    def to_ip(self):
+    def convert_to_ip(self):
         """Convert the DataCollection to IP units"""
-        self._data, self._header.data_type.unit = \
+        self._data, self._header._unit = \
             self._header.data_type.to_ip(
-                self._data, self._header.data_type.unit)
+                self._data, self._header.unit)
+
+    def convert_to_si(self):
+        """Convert the DataCollection to SI units"""
+        self._data, self._header._unit = \
+            self._header.data_type.to_si(
+                self._data, self._header.unit)
+
+    def to_unit(self, unit):
+        """Return a DataCollection in the input units"""
+        new_data_c = self.duplicate()
+        new_data_c.convert_to_unit(unit)
+        return new_data_c
 
     def to_ip(self):
-        """Convert the DataCollection to SI units"""
-        self._data, self._header.data_type.unit = \
-            self._header.data_type.to_si(
-                self._data, self._header.data_type.unit)
+        """Return a DataCollection in IP units"""
+        new_data_c = self.duplicate()
+        new_data_c.convert_to_ip()
+        return new_data_c
+
+    def to_si(self):
+        """Return a DataCollection in SI units"""
+        new_data_c = self.duplicate()
+        new_data_c.convert_to_si()
+        return new_data_c
 
     @staticmethod
     def average(data):

--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -150,6 +150,34 @@ class DataCollection(object):
         """Return a copy of the current data list."""
         return DataCollection(self.data, self.header.duplicate())
 
+    def is_in_range(self, lower=float('-inf'), upper=float('+inf'),
+                    raise_exception=False):
+        """Check if the values are in within lower and upper limits."""
+        for value in self.values:
+            if value < lower or value > upper:
+                if not raise_exception:
+                    return False
+                else:
+                    raise ValueError(
+                        'Values should be between {1} and {2}. Got {3}'.format(
+                            lower, upper, value
+                        )
+                    )
+        return True
+
+    def is_in_range_data_type(self, raise_exception=False):
+        """Check if the values are in permissable ranges for the data_type.
+
+        If this method returns False, the DataCollection's data is
+        physically or mathematically impossible for the data_type."""
+        return self._header.data_type.is_in_range(
+            self.values, self._header.unit, raise_exception)
+
+    def is_in_range_epw(self, raise_exception=False):
+        """Check if the values are in permissable ranges for an EPW file."""
+        return self._header.data_type.is_in_range_epw(
+            self.values, self._header.unit, raise_exception)
+
     def convert_to_unit(self, unit):
         """Convert the DataCollection to the input unit"""
         self._data = [DataPoint(x, self._data[i].datetime) for i, x in enumerate(

--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -147,26 +147,31 @@ class DataCollection(object):
         return self._data
 
     def duplicate(self):
-        """Duplicate current data list."""
-        return DataCollection(self.data, self.header)
+        """Return a copy of the current data list."""
+        return DataCollection(self.data, self.header.duplicate())
 
     def convert_to_unit(self, unit):
         """Convert the DataCollection to the input unit"""
-        self._data = self._header.data_type.to_unit(
-                self._data, unit, self._header.unit)
+        self._data = [DataPoint(x, self._data[i].datetime) for i, x in enumerate(
+            self._header.data_type.to_unit(
+                self._data, unit, self._header.unit))]
         self._header._unit = unit
 
     def convert_to_ip(self):
         """Convert the DataCollection to IP units"""
-        self._data, self._header._unit = \
+        new_values, self._header._unit = \
             self._header.data_type.to_ip(
                 self._data, self._header.unit)
+        self._data = [DataPoint(
+            x, self._data[i].datetime) for i, x in enumerate(new_values)]
 
     def convert_to_si(self):
         """Convert the DataCollection to SI units"""
-        self._data, self._header._unit = \
+        new_values, self._header._unit = \
             self._header.data_type.to_si(
                 self._data, self._header.unit)
+        self._data = [DataPoint(
+            x, self._data[i].datetime) for i, x in enumerate(new_values)]
 
     def to_unit(self, unit):
         """Return a DataCollection in the input units"""

--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -410,7 +410,7 @@ class DataCollection(object):
                 _data[i].value = d.value / timestep
 
         # shift data if half-hour interpolation has been selected.
-        if self.header.middle_hour is True:
+        if self.header.data_type.middle_hour_epw is True:
             shift_dist = int(timestep / 2)
             _data = _data[-shift_dist:] + _data[:-shift_dist]
             for i, d in enumerate(_data):

--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -156,37 +156,37 @@ class DataCollection(object):
 
     def get_highest_values(self, count):
         """Find highest values in a list of DataPoints
-        
+
         Args:
             data: A list of DataPoint to be processed
             count: Number of highest values to account for
-            
+
         Return:
             highest_values: The n highest values in data list, ordered from
                 highest to lowest
-            highest_values_index: Indicies of the n highest values in data 
+            highest_values_index: Indicies of the n highest values in data
                 list, ordered from highest to lowest
         """
         data_points = self._data
-        
+
         values = [obj._value for obj in data_points]
-        
+
         lenght_values = len(values)
-        
+
         count = int(count)
-        
+
         assert count <= lenght_values, \
             'Count must be equal to or smaller than list of data lenght'
-            
+
         assert count > 0, \
             'Count must be higher than zero'
-        
-        highest_values = sorted(values, reverse = True)[0:count]
-        
-        highest_values_index = sorted(range(lenght_values), 
-                                      key = lambda k: values[k],
-                                      reverse = True)[0:count]
-        
+
+        highest_values = sorted(values, reverse=True)[0:count]
+
+        highest_values_index = sorted(range(lenght_values),
+                                      key=lambda k: values[k],
+                                      reverse=True)[0:count]
+
         return highest_values, highest_values_index
 
     @staticmethod
@@ -669,7 +669,7 @@ class DataCollection(object):
         """_data collection representation."""
         if self.header and self.header.data_type and self.header.unit \
                 and self.header.analysis_period:
-                    return "{} ({}) DataCollection\n{}\n...{} values...".format(
+                    return "{} ({})\n{}\n...{} values...".format(
                         self.header.data_type, self.header.unit,
                         self.header.analysis_period, len(self._data))
         else:

--- a/ladybug/datatypenew.py
+++ b/ladybug/datatypenew.py
@@ -1,74 +1,56 @@
 """Ladybug data types."""
+import copy
 import math
-from .euclid import Vector3
 
 PI = math.pi
 
 
-class DataTypes(object):
-    """Available data type classes organized by full name of the data type."""
-    TYPES = {
-        'Generic Type': 'DataTypeBase',
-        'Temperature': 'Temperature',
-        'Dry Bulb Temperature': 'DryBulbTemperature',
-        'Dew Point Temperature': 'DewPointTemperature',
-        'Sky Temperature': 'SkyTemperature',
-        'Mean Radiant Temperature': 'MeanRadiantTemperature',
-        'Relative Humidity': 'RelativeHumidity',
-        }
-
-    @classmethod
-    def type_by_name(cls, type_name):
-        """Return the name of the class using the name of the data type."""
-        assert isinstance(type_name, str), \
-            'type_name must be a text string got {}'.format(type(type_name))
-        data_types = cls.TYPES
-        if type_name.title() in data_types.keys():
-            d_type = None
-            statement = 'd_type = {}()'.format(data_types[type_name.title()])
-            exec(statement)
-            return d_type
-        else:
-            return GenericType(type_name.title())
-
-    def ToString(self):
-        """Overwrite .NET ToString."""
-        return self.__repr__()
-
-    def __repr__(self):
-        """DataTypes representation."""
-        types = ('{}'.format(key) for key in self.TYPES.keys())
-        return '\n'.join(types)
-
-
 class DataTypeBase(object):
-    """Base type for data types.
+    """Base class for data types.
 
     Attributes:
         name: The full name of the data type as a string.
         units: A list of all accetpable units of the data type as abbreviated text.
             The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if such exist).
-            The rest of the list should be any other acceptable units.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
             (eg. [C, F, K])
-        min: Optional lower value for the data type.
-        max: Optional upper value for the data type.
-        missing: Optional missing value for the data type.
-        unit_descr: An optional description of the units if the numerical values
+        min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        unit_descr: An optional description of the units if numerical values
             of these units relate to specific categories.
             (eg. -1 = Cold, 0 = Neutral, +1 = Hot) (eg. 0 = False, 1 = True)
-        cumulative: Boolean value to tell whether the value is cumulative over
-            a time period or represents conditions at an instant in time
-            (or an average over a time period). The default is False.
+        cumulative: Boolean to tell whether the value can be cumulative over
+            a time period or can only represent conditions at an instant or an
+            average over a time period. (Default: False).
+        min_epw: Lower limit for the data type when it occurs in EPW files.
+            (Default: -inf)
+        max_epw: Upper limit for the data type when it occurs in EPW files.
+            (Default: +inf)
+        missing_epw: Missing value for the data type when it occurs in EPW files.
+            (Default: None)
+        middle_hour_epw: Boolean to note whether the data type represents conditions
+            on the half hour (True) as opposed to the hour (False)) when it is
+            found in an EPW file. (Default: False).
     """
 
-    name = 'Generic Type'
+    __slots__ = ('name', 'units', 'min', 'max', 'unit_descr', 'cumulative',
+                 'min_epw', 'max_epw', 'missing_epw', 'middle_hour_epw')
+
+    name = 'Data Type Base'
     units = [None]
     min = float('-inf')
     max = float('+inf')
-    missing = None
+
     unit_descr = ''
     cumulative = False
+
+    min_epw = float('-inf')
+    max_epw = float('+inf')
+    missing_epw = None
+    middle_hour_epw = False
 
     def __init__(self):
         """Init DataType."""
@@ -81,10 +63,12 @@ class DataTypeBase(object):
             data: Data as a dictionary.
                 {
                     "name": data type name as a string
+                    "units": list of acceptable units
                 }
         """
         assert 'name' in data, 'Required keyword "name" is missing!'
-        return DataTypes.type_by_name(data['name'])
+        assert 'units' in data, 'Required keyword "units" is missing!'
+        return DataTypes.type_by_name_and_unit(data['name'], data['units'][0])
 
     def is_unit_acceptable(self, unit, raise_exception=False):
         """Check if a certain unit is acceptable for the data type.
@@ -105,27 +89,33 @@ class DataTypeBase(object):
                 )
             )
 
-    def to_ip(self, data):
-        """Method that converts a list of values from SI to IP."""
+    def to_unit(self, values, unit, from_unit=None):
+        """Convert a list of values to a given unit from a given from_unit."""
+        raise NotImplementedError(
+            'to_unit is not implemented on %s' % self.__class__.__name__
+        )
+
+    def to_ip(self, values, from_unit=None):
+        """Converts a list of values to IP from a given from_unit."""
         raise NotImplementedError(
             'to_ip is not implemented on %s' % self.__class__.__name__
         )
 
-    def to_si(self, data):
-        """Method that converts a list of values from IP to SI."""
+    def to_si(self, values, from_unit=None):
+        """Convert a list of values to SI from a given from_unit."""
         raise NotImplementedError(
             'to_si is not implemented on %s' % self.__class__.__name__
         )
 
     def is_missing(self, values):
-        """Check if a list of values contains missing data."""
+        """Check if a list of values contains missing data when in an EPW."""
         for value in values:
-            if value == self.missing:
+            if value == self.missing_epw:
                 return True
         return False
 
     def is_in_range(self, values, unit=None, raise_exception=False):
-        """check if a list of values is within acceptable ranges.
+        """Check if a list of values is within acceptable ranges.
 
         Args:
             values: A list of values.
@@ -133,20 +123,55 @@ class DataTypeBase(object):
                 unit will be assumed.
             raise_exception: Set to True to raise an exception if not in range.
         """
+        self._check_values(values)
         if unit is None or unit == self.units[0]:
             minimum = self.min
             maximum = self.max
         else:
             self.is_unit_acceptable(unit, True)
             min_statement = "minimum = self.{}_to_{}(self.min)".format(
-                self.units[0], unit)
+                self._clean(self.units[0]), self._clean(unit))
             max_statement = "maximum = self.{}_to_{}(self.max)".format(
-                self.units[0], unit)
+                self._clean(self.units[0]), self._clean(unit))
             exec(min_statement)
             exec(max_statement)
 
         for value in values:
-            if value == self.missing:
+            if value < minimum or value > maximum:
+                if not raise_exception:
+                    return False
+                else:
+                    raise ValueError(
+                        '{0} should be between {1} and {2}. Got {3}'.format(
+                            self.__class__.__name__, self.min, self.max, value
+                        )
+                    )
+        return True
+
+    def is_in_epw_range(self, values, unit=None, raise_exception=False):
+        """Check if a list of values is within acceptable ranges for an EPW file.
+
+        Args:
+            values: A list of values.
+            unit: The unit of the values.  If not specified, the default metric
+                unit will be assumed.
+            raise_exception: Set to True to raise an exception if not in range.
+        """
+        self._check_values(values)
+        if unit is None or unit == self.units[0]:
+            minimum = self.min_epw
+            maximum = self.max_epw
+        else:
+            self.is_unit_acceptable(unit, True)
+            min_statement = "minimum = self.{}_to_{}(self.min_epw)".format(
+                self._clean(self.units[0]), self._clean(unit))
+            max_statement = "maximum = self.{}_to_{}(self.max_epw)".format(
+                self._clean(self.units[0]), self._clean(unit))
+            exec(min_statement)
+            exec(max_statement)
+
+        for value in values:
+            if self.is_missing(value):
                 continue
             if value < minimum or value > maximum:
                 if not raise_exception:
@@ -160,10 +185,41 @@ class DataTypeBase(object):
         return True
 
     def to_json(self):
-        "Get data type as a json object"
+        """Get data type as a json object"""
         return {
-            'name': self.name
+            'name': self.name,
+            'units': self.units
         }
+
+    def _check_values(self, values):
+        """Check to be sure values are numbers before doing numerical operations."""
+        if len(values) > 0:
+            assert isinstance(values[0], (float, int)), \
+                "values must be numbers to perform math operations. Got {}".format(
+                    type(values[0]))
+
+    def _to_unit_base(self, base_unit, values, unit, from_unit):
+        """Return values in a given unit given the input from_unit."""
+        self._check_values(values)
+        if not from_unit == base_unit:
+            self.is_unit_acceptable(from_unit, True)
+            statement = 'values = [self._{}_to_{}(val) for val in values]'.format(
+                self._clean(from_unit), self._clean(base_unit))
+            exec(statement)
+        if not unit == base_unit:
+            self.is_unit_acceptable(unit, True)
+            statement = 'values = [self._{}_to_{}(val) for val in values]'.format(
+                self._clean(base_unit), self._clean(unit))
+            exec(statement)
+        return values
+
+    def _clean(self, unit):
+        """Clean out special characters from unit abbreviations."""
+        return unit.replace(
+            '/', '_').replace(
+                '-', '').replace(
+                    ' ', '').replace(
+                        '%', 'pct')
 
     @property
     def isDataType(self):
@@ -179,49 +235,65 @@ class DataTypeBase(object):
         return self.name
 
 
-class GenericType(DataTypeBase):
-    """Type for any data without a recognizable name."""
+""" ************ FUNDAMENTAL DATA TYPES ************ """
+# TODO: Add data types for Area, Volume, MassFlowRate
+# TODO: Add data types for Conductivity, ThermalResistance, UValue, RValue(with clo)
+# TODO: Add data types for PMV, MetabolicRate, ThermalCondition, Comfort
+# TODO: Add PPD to hinherit from Percentage, SET and UTCI to inherit from Temperature
+
+
+class Unitless(DataTypeBase):
+    """Type for any data without a recognizable name and no units."""
     def __init__(self, name):
         """Init Generic Type."""
         self.name = name
 
 
+class GenericType(DataTypeBase):
+    """Type for any data without a recognizable name."""
+    def __init__(self, name, unit):
+        """Init Generic Type."""
+        self.name = name
+        self.units = [unit]
+
+    def to_ip(self, values):
+        """Return values in IP."""
+        return values, self.units[0]
+
+    def to_si(self, values, from_unit='F'):
+        """Return values in SI."""
+        return values, self.units[0]
+
+
 class Temperature(DataTypeBase):
-    """Temperature."""
+    """Temperature"""
     name = 'Temperature'
     units = ['C', 'F', 'K']
     min = -273.15
 
-    def C_to_F(self, values):
-        """Return a list of values in F assuming input values are in C."""
-        return [value * 9 / 5 + 32 for value in values]
+    def _C_to_F(self, value):
+        return value * 9 / 5 + 32
 
-    def C_to_K(self, values):
-        """Return a list of values in K assuming input values are in C."""
-        return [value + 273.15 for value in values]
+    def _C_to_K(self, value):
+        return value + 273.15
 
-    def F_to_C(self, values):
-        """Return a list of values in C assuming input values are in F."""
-        return [(value - 32) * 5 / 9 for value in values]
+    def _F_to_C(self, value):
+        return (value - 32) * 5 / 9
 
-    def K_to_C(self, values):
-        """Return a list of values in K assuming input values are in C."""
-        return [value - 273.15 for value in values]
+    def _K_to_C(self, value):
+        return value - 273.15
 
-    def to_ip(self, values, unit='C'):
-        """Return a list of values in F given the input unit."""
-        if not unit == 'C':
-            self.is_unit_acceptable(unit, True)
-            statement = 'values = self.{}_to_C(values)'.format(unit)
-            exec(statement)
-        return self.C_to_F(values)
+    def to_unit(self, values, unit, from_unit='C'):
+        """Return values in a given unit given the input from_unit."""
+        return self._to_unit_base('C', values, unit, from_unit)
 
-    def to_si(self, values, unit='F'):
-        """Return a list of values in C given the input unit."""
-        self.is_unit_acceptable(unit, True)
-        statement = 'values = self.{}_to_C(values)'.format(unit)
-        exec(statement)
-        return values
+    def to_ip(self, values, from_unit='C'):
+        """Return values in F given the input from_unit."""
+        return self.to_unit(values, 'F', from_unit), 'F'
+
+    def to_si(self, values, from_unit='F'):
+        """Return values in C given the input from_unit."""
+        return self.to_unit(values, 'F', from_unit), 'C'
 
     @property
     def isTemperature(self):
@@ -229,47 +301,113 @@ class Temperature(DataTypeBase):
         return True
 
 
-class DryBulbTemperature(Temperature):
-    """Dry Bulb Temperature."""
-    name = 'Dry Bulb Temperature'
-    missing = 99.9
+class Percentage(DataTypeBase):
+    """Percentage"""
+    name = 'Percentage'
+    units = ['%', 'fraction', 'tenths', 'thousandths']
 
+    def _pct_to_fraction(self, value):
+        return value / 100
 
-class DewPointTemperature(Temperature):
-    """Dew Point Temperature."""
-    name = 'Dew Point Temperature'
-    missing = 99.9
+    def _pct_to_tenths(self, value):
+        return value / 10
 
+    def _pct_to_thousandths(self, value):
+        return value * 10
 
-class SkyTemperature(Temperature):
-    """Sky Temperature."""
-    name = 'Sky Temperature'
-    missing = 99.9
+    def _fraction_to_pct(self, value):
+        return value * 100
 
+    def _tenths_to_pct(self, value):
+        return value * 10
 
-class MeanRadiantTemperature(Temperature):
-    """Mean Radiant Temperature."""
-    name = 'Mean Radiant Temperature'
+    def _thousandths_to_pct(self, value):
+        return value / 10
 
+    def to_unit(self, values, unit, from_unit='%'):
+        """Return values in a given unit given the input from_unit."""
+        return self._to_unit_base('%', values, unit, from_unit)
 
-class RelativeHumidity(DataTypeBase):
-    """Relative Humidity."""
-    name = 'Relative Humidity'
-    units = ['%']
-    min = 0
-    max = 100
-    missing = 999
+    def to_ip(self, values, from_unit='%'):
+        """Return values in IP given the input from_unit."""
+        return self.to_unit(values, '%', from_unit), '%'
 
-    def to_ip(self, values):
-        """Return the value in IP."""
-        return values
-
-    def to_si(self, values):
-        """Return the value in SI."""
-        return values
+    def to_si(self, values, from_unit='%'):
+        """Return values in SI given the input from_unit."""
+        return self.to_unit(values, '%', from_unit), '%'
 
     @property
-    def isRelativeHumidity(self):
+    def isPercentage(self):
+        """Return True."""
+        return True
+
+
+class Distance(DataTypeBase):
+    """Distance"""
+    name = 'Distance'
+    units = ['m', 'ft', 'mm', 'in', 'km', 'mi', 'cm']
+    min = 0
+
+    def _m_to_ft(self, value):
+        return value * 3.28084
+
+    def _m_to_mm(self, value):
+        return value * 1000
+
+    def _m_to_in(self, value):
+        return value * 39.3701
+
+    def _m_to_km(self, value):
+        return value / 1000
+
+    def _m_to_mi(self, value):
+        return value / 1609.344
+
+    def _m_to_cm(self, value):
+        return value * 100
+
+    def _ft_to_m(self, value):
+        return value / 3.28084
+
+    def _mm_to_m(self, value):
+        return value / 1000
+
+    def _in_to_m(self, value):
+        return value / 39.3701
+
+    def _km_to_m(self, value):
+        return value * 1000
+
+    def _mi_to_m(self, value):
+        return value * 1609.344
+
+    def _cm_to_m(self, value):
+        return value / 100
+
+    def to_unit(self, values, unit, from_unit='m'):
+        """Return values in a given unit given the input from_unit."""
+        return self._to_unit_base('m', values, unit, from_unit)
+
+    def to_ip(self, values, from_unit='m'):
+        """Return values in IP given the input from_unit."""
+        if from_unit == 'mm' or from_unit == 'in':
+            return self.to_unit(values, 'in', from_unit), 'in'
+        elif from_unit == 'km' or from_unit == 'mi':
+            return self.to_unit(values, 'mi', from_unit), 'mi'
+        else:
+            return self.to_unit(values, 'ft', from_unit), 'ft'
+
+    def to_si(self, values, from_unit='ft'):
+        """Return values in SI given the input from_unit."""
+        if from_unit == 'in' or from_unit == 'mm':
+            return self.to_unit(values, 'mm', from_unit), 'mm'
+        elif from_unit == 'mi' or from_unit == 'km':
+            return self.to_unit(values, 'km', from_unit), 'km'
+        else:
+            return self.to_unit(values, 'm', from_unit), 'm'
+
+    @property
+    def isDistance(self):
         """Return True."""
         return True
 
@@ -277,43 +415,903 @@ class RelativeHumidity(DataTypeBase):
 class Pressure(DataTypeBase):
     """Pressure"""
     name = 'Pressure'
-    units = ['Pa', 'inHg', 'atm', 'bar', 'Torr', 'psi', 'inH2O', 'kPa']
+    units = ['Pa', 'inHg', 'atm', 'bar', 'Torr', 'psi', 'inH2O']
 
-    def Pa_to_inHg(self, values):
-        """Return the value in inHg given an input in Pa."""
-        return [value * 0.0002953 for value in values]
+    def _Pa_to_inHg(self, value):
+        return value * 0.0002953
 
-    def Pa_to_atm(self, values):
-        """Return the value in atm given an input in Pa."""
-        return [value / 101325 for value in values]
+    def _Pa_to_atm(self, value):
+        return value / 101325
 
-    def Pa_to_bar(self, values):
-        """Return the value in bat given an input in Pa."""
-        return [value / 100000 for value in values]
+    def _Pa_to_bar(self, value):
+        return value / 100000
 
-    def inHg_to_Pa(self, values):
-        """Return the value in Pa given an input in inHg."""
-        return [value / 0.0002953 for value in values]
+    def _Pa_to_Torr(self, value):
+        return value * 0.00750062
 
-    def atm_to_Pa(self, values):
-        """Return the value in atm given an input in Pa."""
-        return [value * 101325 for value in values]
+    def _Pa_to_psi(self, value):
+        return value * 0.000145038
 
-    def bar_to_Pa(self, values):
-        """Return the value in bar given an input in Pa."""
-        return [value * 100000 for value in values]
+    def _Pa_to_inH2O(self, value):
+        return value * 0.00401865
 
-    def to_ip(self, values, unit='Pa'):
-        """Return a list of values in inHg given the input unit."""
-        if not unit == 'Pa':
-            self.is_unit_acceptable(unit, True)
-            statement = 'values = self.{}_to_Pa(values)'.format(unit)
+    def _inHg_to_Pa(self, value):
+        return value / 0.0002953
+
+    def _atm_to_Pa(self, value):
+        return value * 101325
+
+    def _bar_to_Pa(self, value):
+        return value * 100000
+
+    def _Torr_to_Pa(self, value):
+        return value / 0.00750062
+
+    def _psi_to_Pa(self, value):
+        return value / 0.000145038
+
+    def _inH2O_to_Pa(self, value):
+        return value / 0.00401865
+
+    def to_unit(self, values, unit, from_unit='Pa'):
+        """Return values in a given unit given the input from_unit."""
+        return self._to_unit_base('Pa', values, unit, from_unit)
+
+    def to_ip(self, values, from_unit='Pa'):
+        """Return values in inHg given the input from_unit."""
+        return self.to_unit(values, 'inHg', from_unit), 'inHg'
+
+    def to_si(self, values, from_unit='inHg'):
+        """Return values in Pa given the input from_unit."""
+        return self.to_unit(values, 'Pa', from_unit), 'Pa'
+
+    @property
+    def isPressure(self):
+        """Return True."""
+        return True
+
+
+class Energy(DataTypeBase):
+    """Energy"""
+    name = 'Energy'
+    units = ['kWh', 'kBtu', 'Wh', 'Btu', 'MMBtu', 'J', 'kJ', 'GJ',
+             'therm', 'cal', 'kcal']
+    cumulative = True
+
+    def _kWh_to_kBtu(self, value):
+        return value * 3.41214
+
+    def _kWh_to_Wh(self, value):
+        return value * 1000
+
+    def _kWh_to_Btu(self, value):
+        return value * 3412.14
+
+    def _kWh_to_MMBtu(self, value):
+        return value * 0.00341214
+
+    def _kWh_to_J(self, value):
+        return value * 3600000
+
+    def _kWh_to_kJ(self, value):
+        return value * 3600
+
+    def _kWh_to_GJ(self, value):
+        return value * 3.6
+
+    def _kWh_to_therm(self, value):
+        return value * 0.0341214
+
+    def _kWh_to_cal(self, value):
+        return value * 860421
+
+    def _kWh_to_kcal(self, value):
+        return value * 860.421
+
+    def _kBtu_to_kWh(self, value):
+        return value / 3.41214
+
+    def _Wh_to_kWh(self, value):
+        return value / 1000
+
+    def _Btu_to_kWh(self, value):
+        return value / 3412.14
+
+    def _MMBtu_to_kWh(self, value):
+        return value / 0.00341214
+
+    def _J_to_kWh(self, value):
+        return value / 3600000
+
+    def _kJ_to_kWh(self, value):
+        return value / 3600
+
+    def _GJ_to_kWh(self, value):
+        return value / 3.6
+
+    def _therm_to_kWh(self, value):
+        return value / 0.0341214
+
+    def _cal_to_kWh(self, value):
+        return value / 860421
+
+    def _kcal_to_kWh(self, value):
+        return value / 860.421
+
+    def to_unit(self, values, unit, from_unit='kWh'):
+        """Return values in a given unit given the input from_unit."""
+        return self._to_unit_base('kWh', values, unit, from_unit)
+
+    def to_ip(self, values, from_unit='kWh'):
+        """Return values in IP given the input from_unit."""
+        if from_unit == 'Wh' or from_unit == 'Btu':
+            return self.to_unit(values, 'Btu', from_unit), 'Btu'
+        else:
+            return self.to_unit(values, 'kBtu', from_unit), 'kBtu'
+
+    def to_si(self, values, from_unit='kBtu'):
+        """Return values in SI given the input from_unit."""
+        if from_unit == 'Btu' or from_unit == 'Wh':
+            return self.to_unit(values, 'Wh', from_unit), 'Wh'
+        else:
+            return self.to_unit(values, 'kWh', from_unit), 'kWh'
+
+    @property
+    def isEnergy(self):
+        """Return True."""
+        return True
+
+
+class EnergyIntensity(DataTypeBase):
+    """Energy Intensity"""
+    name = 'Energy Intensity'
+    units = ['kWh/m2', 'kBtu/ft2', 'Wh/m2', 'Btu/ft2']
+    cumulative = True
+
+    def _kWh_m2_to_kBtu_ft2(self, value):
+        return value * 0.316998
+
+    def _kWh_m2_to_Wh_m2(self, value):
+        return value * 1000
+
+    def _kWh_m2_to_Btu_ft2(self, value):
+        return value * 316.998
+
+    def _kBtu_ft2_to_kWh_m2(self, value):
+        return value / 0.316998
+
+    def _Wh_m2_to_kWh_m2(self, value):
+        return value / 1000
+
+    def _Btu_ft2_to_kWh_m2(self, value):
+        return value / 316.998
+
+    def to_unit(self, values, unit, from_unit='kWh/m2'):
+        """Return values in a given unit given the input from_unit."""
+        return self._to_unit_base('kWh/m2', values, unit, from_unit)
+
+    def to_ip(self, values, from_unit='kWh/m2'):
+        """Return values in IP given the input from_unit."""
+        if from_unit == 'Wh/m2' or from_unit == 'Btu/ft2':
+            return self.to_unit(values, 'Btu/ft2', from_unit), 'Btu/ft2'
+        else:
+            return self.to_unit(values, 'kBtu/ft2', from_unit), 'kBtu/ft2'
+
+    def to_si(self, values, from_unit='kBtu/ft2'):
+        """Return values in SI given the input from_unit."""
+        if from_unit == 'Btu/ft2' or from_unit == 'Wh/m2':
+            return self.to_unit(values, 'Wh/m2', from_unit), 'Wh/m2'
+        else:
+            return self.to_unit(values, 'kWh/m2', from_unit), 'kWh/m2'
+
+    @property
+    def isEnergyIntensity(self):
+        """Return True."""
+        return True
+
+
+class Power(DataTypeBase):
+    """Power"""
+    name = 'Power'
+    units = ['W', 'Btu/h', 'kW', 'kBtu/h', 'TR', 'hp']
+
+    def _W_to_Btu_h(self, value):
+        return value * 3.41214
+
+    def _W_to_kW(self, value):
+        return value / 1000
+
+    def _W_to_kBtu_h(self, value):
+        return value * 0.00341214
+
+    def _W_to_TR(self, value):
+        return value / 3516.85
+
+    def _W_to_hp(self, value):
+        return value / 745.7
+
+    def _Btu_h_to_W(self, value):
+        return value / 3.41214
+
+    def _kW_to_W(self, value):
+        return value * 1000
+
+    def _kBtu_h_to_W(self, value):
+        return value / 0.00341214
+
+    def _TR_to_W(self, value):
+        return value * 3516.85
+
+    def _hp_to_W(self, value):
+        return value * 745.7
+
+    def to_unit(self, values, unit, from_unit='W'):
+        """Return values in a given unit given the input from_unit."""
+        return self._to_unit_base('W', values, unit, from_unit)
+
+    def to_ip(self, values, from_unit='W'):
+        """Return values in IP given the input from_unit."""
+        if from_unit == 'kW' or from_unit == 'kBtu/h':
+            return self.to_unit(values, 'kBtu/h', from_unit), 'kBtu/h'
+        else:
+            return self.to_unit(values, 'Btu/h', from_unit), 'Btu/h'
+
+    def to_si(self, values, from_unit='Btu/h'):
+        """Return values in SI given the input from_unit."""
+        if from_unit == 'kBtu/h' or from_unit == 'kW':
+            return self.to_unit(values, 'kW', from_unit), 'kW'
+        else:
+            return self.to_unit(values, 'W', from_unit), 'W'
+
+    @property
+    def isPower(self):
+        """Return True."""
+        return True
+
+
+class EnergyFlux(DataTypeBase):
+    """Energy Flux"""
+    name = 'Energy Flux'
+    units = ['W/m2', 'Btu/h-ft2', 'kW/m2', 'kBtu/h-ft2', 'W/ft2']
+
+    def _W_m2_to_Btu_hft2(self, value):
+        return value / 3.15459075
+
+    def _W_m2_to_kW_m2(self, value):
+        return value / 1000
+
+    def _W_m2_to_kBtu_hft2(self, value):
+        return value / 3154.59075
+
+    def _W_m2_to_W_ft2(self, value):
+        return value / 10.7639
+
+    def _Btu_hft2_to_W_m2(self, value):
+        return value * 3.15459075
+
+    def _kW_m2_to_W_m2(self, value):
+        return value * 1000
+
+    def _kBtu_hft2_to_W_m2(self, value):
+        return value * 3154.59075
+
+    def _W_ft2_to_W_m2(self, value):
+        return value * 10.7639
+
+    def to_unit(self, values, unit, from_unit='W/m2'):
+        """Return values in a given unit given the input from_unit."""
+        return self._to_unit_base('W/m2', values, unit, from_unit)
+
+    def to_ip(self, values, from_unit='W/m2'):
+        """Return values in IP given the input from_unit."""
+        if from_unit == 'kW/m2' or from_unit == 'kBtu/h-ft2':
+            return self.to_unit(values, 'kBtu/h-ft2', from_unit), 'kBtu/h-ft2'
+        else:
+            return self.to_unit(values, 'Btu/h-ft2', from_unit), 'Btu/h-ft2'
+
+    def to_si(self, values, from_unit='Btu/h-ft2'):
+        """Return values in SI given the input from_unit."""
+        if from_unit == 'kBtu/h-ft2' or from_unit == 'kW/m2':
+            return self.to_unit(values, 'kW/m2', from_unit), 'kW/m2'
+        else:
+            return self.to_unit(values, 'W/m2', from_unit), 'W/m2'
+
+    @property
+    def isEnergyFlux(self):
+        """Return True."""
+        return True
+
+
+class Illuminance(DataTypeBase):
+    """Illuminance"""
+    name = 'Illuminance'
+    units = ['lux', 'fc']
+    min = 0
+    min_epw = 0
+    missing_epw = 999999  # note will be missing if >= 999900
+
+    def _lux_to_fc(self, value):
+        return value / 10.7639
+
+    def _fc_to_lux(self, value):
+        return value * 10.7639
+
+    def to_unit(self, values, unit, from_unit='lux'):
+        """Return values in a given unit given the input from_unit."""
+        return self._to_unit_base('lux', values, unit, from_unit)
+
+    def to_ip(self, values, from_unit='lux'):
+        """Return values in fc given the input from_unit."""
+        return self.to_unit(values, 'fc', from_unit), 'fc'
+
+    def to_si(self, values, from_unit='fc'):
+        """Return values in lux given the input from_unit."""
+        return self.to_unit(values, 'lux', from_unit), 'lux'
+
+    @property
+    def isIlluminance(self):
+        """Return True."""
+        return True
+
+
+class Luminance(DataTypeBase):
+    """Luminance"""
+    name = 'Luminance'
+    units = ['cd/m2', 'cd/ft2']
+    min = 0
+    min_epw = 0
+    missing_epw = 9999  # note will be missing if >= 999900
+
+    def _cd_m2_to_cd_ft2(self, value):
+        return value / 10.7639
+
+    def _cd_ft2_to_cd_m2(self, value):
+        return value * 10.7639
+
+    def to_unit(self, values, unit, from_unit='cd/m2'):
+        """Return values in a given unit given the input from_unit."""
+        return self._to_unit_base('cd/m2', values, unit, from_unit)
+
+    def to_ip(self, values, from_unit='cd/m2'):
+        """Return values in cd/ft2 given the input from_unit."""
+        return self.to_unit(values, 'cd/ft2', from_unit), 'cd/ft2'
+
+    def to_si(self, values, from_unit='cd/ft2'):
+        """Return values in cd/m2 given the input from_unit."""
+        return self.to_unit(values, 'cd/m2', from_unit), 'cd/m2'
+
+    @property
+    def isLuminance(self):
+        """Return True."""
+        return True
+
+
+class Angle(DataTypeBase):
+    """Angle"""
+    name = 'Angle'
+    units = ['degrees', 'radians']
+
+    def _degrees_to_radians(self, value):
+        return (value * PI) / 180
+
+    def _radians_to_degrees(self, value):
+        return (value / PI) * 180
+
+    def to_unit(self, values, unit, from_unit='degrees'):
+        """Return values in a given unit given the input from_unit."""
+        return self._to_unit_base('degrees', values, unit, from_unit)
+
+    def to_ip(self, values, from_unit='degrees'):
+        """Return values in IP."""
+        return values, from_unit
+
+    def to_si(self, values, from_unit='degrees'):
+        """Return values in SI."""
+        return values, from_unit
+
+    @property
+    def isAngle(self):
+        """Return True."""
+        return True
+
+
+class Mass(DataTypeBase):
+    """Mass"""
+    name = 'Mass'
+    units = ['kg', 'lb', 'g', 'tonne']
+    min = 0
+
+    def _kg_to_lb(self, value):
+        return value * 2.20462
+
+    def _kg_to_g(self, value):
+        return value * 1000
+
+    def _kg_to_tonne(self, value):
+        return value / 1000
+
+    def _lb_to_kg(self, value):
+        return value / 2.20462
+
+    def _g_to_kg(self, value):
+        return value / 1000
+
+    def _tonne_to_kg(self, value):
+        return value * 1000
+
+    def to_unit(self, values, unit, from_unit='kg'):
+        """Return values in a given unit given the input from_unit."""
+        return self._to_unit_base('kg', values, unit, from_unit)
+
+    def to_ip(self, values, from_unit='kg'):
+        """Return values in lb given the input from_unit."""
+        return self.to_unit(values, 'lb', from_unit), 'lb'
+
+    def to_si(self, values, from_unit='lb'):
+        """Return values in kg given the input from_unit."""
+        return self.to_unit(values, 'kg', from_unit), 'kg'
+
+    @property
+    def isMass(self):
+        """Return True."""
+        return True
+
+
+class Speed(DataTypeBase):
+    """Speed"""
+    name = 'Speed'
+    units = ['m/s', 'mph', 'km/h', 'knot', 'ft/s']
+    min = 0
+
+    def _m_s_to_mph(self, value):
+        return value * 2.23694
+
+    def _m_s_to_km_h(self, value):
+        return value * 3.6
+
+    def _m_s_to_knot(self, value):
+        return value * 1.94384
+
+    def _m_s_to_ft_s(self, value):
+        return value * 3.28084
+
+    def _mph_to_m_s(self, value):
+        return value / 2.23694
+
+    def _km_h_to_m_s(self, value):
+        return value / 3.6
+
+    def _knot_to_m_s(self, value):
+        return value / 1.94384
+
+    def _ft_s_to_m_s(self, value):
+        return value / 3.28084
+
+    def to_unit(self, values, unit, from_unit='m/s'):
+        """Return values in a given unit given the input from_unit."""
+        return self._to_unit_base('m/s', values, unit, from_unit)
+
+    def to_ip(self, values, from_unit='m/s'):
+        """Return values in mph given the input from_unit."""
+        return self.to_unit(values, 'mph', from_unit), 'mph'
+
+    def to_si(self, values, from_unit='mph'):
+        """Return values in m/s given the input from_unit."""
+        return self.to_unit(values, 'm/s', from_unit), 'm/s'
+
+    @property
+    def isSpeed(self):
+        """Return True."""
+        return True
+
+
+class VolumeFlowRate(DataTypeBase):
+    """Volume Flow Rate"""
+    name = 'Volume Flow Rate'
+    units = ['m3/s', 'ft3/s', 'L/s', 'cfm', 'gpm']
+    min = 0
+
+    def _m3_s_to_ft3_s(self, value):
+        return value * 35.3147
+
+    def _m3_s_to_L_s(self, value):
+        return value * 1000
+
+    def _m3_s_to_cfm(self, value):
+        return value * 2118.88
+
+    def _m3_s_to_gpm(self, value):
+        return value * 15850.3231
+
+    def _ft3_s_to_m3_s(self, value):
+        return value / 35.3147
+
+    def _L_s_to_m3_s(self, value):
+        return value / 1000
+
+    def _cfm_to_m3_s(self, value):
+        return value / 2118.88
+
+    def _gpm_to_m3_s(self, value):
+        return value / 15850.3231
+
+    def to_unit(self, values, unit, from_unit='m3/s'):
+        """Return values in a given unit given the input from_unit."""
+        return self._to_unit_base('m3/s', values, unit, from_unit)
+
+    def to_ip(self, values, from_unit='m3/s'):
+        """Return values in mph given the input from_unit."""
+        return self.to_unit(values, 'ft3/s', from_unit), 'ft3/s'
+
+    def to_si(self, values, from_unit='ft3/s'):
+        """Return values in m/s given the input from_unit."""
+        return self.to_unit(values, 'm3/s', from_unit), 'm3/s'
+
+    @property
+    def isFlowRate(self):
+        """Return True."""
+        return True
+
+
+""" ************ DERIVATIVE DATA TYPES ************ """
+
+
+class DryBulbTemperature(Temperature):
+    name = 'Dry Bulb Temperature'
+    min_epw = -70
+    max_epw = 70
+    missing_epw = 99.9
+
+
+class DewPointTemperature(Temperature):
+    name = 'Dew Point Temperature'
+    min_epw = -70
+    max_epw = 70
+    missing_epw = 99.9
+
+
+class SkyTemperature(Temperature):
+    name = 'Sky Temperature'
+
+
+class MeanRadiantTemperature(Temperature):
+    name = 'Mean Radiant Temperature'
+
+
+class RelativeHumidity(Percentage):
+    name = 'Relative Humidity'
+    min = 0
+    min_epw = 0
+    max_epw = 110
+    missing_epw = 999
+
+
+class TotalSkyCover(Percentage):
+    # (used if Horizontal IR Intensity missing)
+    name = 'Total Sky Cover'
+    min = 0
+    max = 100
+    min_epw = 0
+    max_epw = 100
+    missing_epw = 99
+
+
+class OpaqueSkyCover(Percentage):
+    # (used if Horizontal IR Intensity missing)
+    name = 'Opaque Sky Cover'
+    min = 0
+    max = 100
+    min_epw = 0
+    max_epw = 100
+    missing_epw = 99
+
+
+class AerosolOpticalDepth(Percentage):
+    name = 'Aerosol Optical Depth'
+    min = 0
+    max = 100
+    min_epw = 0
+    max_epw = 100
+    missing_epw = 0.999
+
+
+class Albedo(Percentage):
+    name = 'Albedo'
+    min = 0
+    max = 100
+    min_epw = 0
+    max_epw = 100
+    missing_epw = 0.999
+
+
+class LiquidPrecipitationQuantity(Percentage):
+    name = 'LiquidPrecipitationQuantity'
+    min = 0
+    min_epw = 0
+    max_epw = 100
+    missing_epw = 99
+
+
+class AtmosphericStationPressure(Pressure):
+    name = 'Atmospheric Station Pressure'
+    min = 0
+    min_epw = 31000
+    max_epw = 120000
+    missing_epw = 999999
+
+
+class Radiation(EnergyIntensity):
+    name = 'Radiation'
+    min = 0
+    min_epw = 0
+    missing_epw = 9999
+
+    @property
+    def isRadiation(self):
+        """Return True."""
+        return True
+
+
+class GlobalHorizontalRadiation(Radiation):
+    name = 'Global Horizontal Radiation'
+    middle_hour_epw = True
+
+
+class DirectNormalRadiation(Radiation):
+    name = 'Direct Normal Radiation'
+    middle_hour_epw = True
+
+
+class DiffuseHorizontalRadiation(Radiation):
+    name = 'Diffuse Horizontal Radiation'
+    middle_hour_epw = True
+
+
+class HorizontalInfraredRadiationIntensity(Radiation):
+    name = 'Horizontal Infrared Radiation Intensity'
+
+
+class ExtraterrestrialHorizontalRadiation(Radiation):
+    name = 'Extraterrestrial Horizontal Radiation'
+    middle_hour_epw = True
+
+
+class ExtraterrestrialDirectNormalRadiation(Radiation):
+    name = 'Extraterrestrial Direct Normal Radiation'
+    middle_hour_epw = True
+
+
+class Irradiance(EnergyFlux):
+    name = 'Irradiance'
+    min = 0
+    min_epw = 0
+    missing_epw = 9999
+
+    @property
+    def isIrradiance(self):
+        """Return True."""
+        return True
+
+
+class GlobalHorizontalIrradiance(Irradiance):
+    name = 'Global Horizontal Irradiance'
+    middle_hour_epw = True
+
+
+class DirectNormalIrradiance(Irradiance):
+    name = 'Direct Normal Irradiance'
+    middle_hour_epw = True
+
+
+class DiffuseHorizontalIrradiance(Irradiance):
+    name = 'Diffuse Horizontal Irradiance'
+    middle_hour_epw = True
+
+
+class HorizontalInfraredRadiationIrradiance(Irradiance):
+    name = 'Horizontal Infrared Irradiance'
+
+
+class GlobalHorizontalIlluminance(Illuminance):
+    name = 'Global Horizontal Illuminance'
+    middle_hour_epw = True
+
+
+class DirectNormalIlluminance(Illuminance):
+    name = 'Direct Normal Illuminance'
+    middle_hour_epw = True
+
+
+class DiffuseHorizontalIlluminance(Illuminance):
+    name = 'Diffuse Horizontal Illuminance'
+    middle_hour_epw = True
+
+
+class ZenithLuminance(Luminance):
+    name = 'Zenith Luminance'
+    middle_hour_epw = True
+
+
+class WindDirection(Angle):
+    name = 'Wind Direction'
+    min_epw = 0
+    max_epw = 360
+    missing_epw = 999
+
+
+class WindSpeed(Speed):
+    name = 'Wind Speed'
+    min_epw = 0
+    max_epw = 40
+    missing_epw = 999
+
+
+class Visibility(Distance):
+    name = 'Visibility'
+    missing_epw = 9999
+
+
+class CeilingHeight(Distance):
+    name = 'Ceiling Height'
+    missing_epw = 99999
+
+
+class PrecipitableWater(Distance):
+    name = 'Precipitable Water'
+    missing_epw = 999
+
+
+class SnowDepth(Distance):
+    name = 'Snow Depth'
+    missing_epw = 999
+
+
+class LiquidPrecipitationDepth(Distance):
+    name = 'Liquid Precipitation Depth'
+    missing_epw = 999
+
+
+class DaysSinceLastSnowfall(DataTypeBase):
+    name = 'Days Since Last Snowfall'
+    missing_epw = 99
+
+
+class DataTypes(object):
+    """Available data type classes organized by full name of the data type."""
+    TYPES = (
+        'Temperature',
+        'Percentage',
+        'Distance',
+        'Pressure',
+        'Energy',
+        'EnergyIntensity',
+        'Power',
+        'EnergyFlux',
+        'Illuminance',
+        'Luminance',
+        'Angle',
+        'Mass',
+        'Speed',
+        'VolumeFlowRate',
+        'DryBulbTemperature',
+        'DewPointTemperature',
+        'SkyTemperature',
+        'MeanRadiantTemperature',
+        'RelativeHumidity',
+        'TotalSkyCover',
+        'OpaqueSkyCover',
+        'AerosolOpticalDepth',
+        'Albedo',
+        'LiquidPrecipitationQuantity',
+        'AtmosphericStationPressure',
+        'Radiation',
+        'GlobalHorizontalRadiation',
+        'DirectNormalRadiation',
+        'DiffuseHorizontalRadiation',
+        'HorizontalInfraredRadiationIntensity',
+        'ExtraterrestrialHorizontalRadiation',
+        'ExtraterrestrialDirectNormalRadiation',
+        'Irradiance',
+        'GlobalHorizontalIrradiance',
+        'DirectNormalIrradiance',
+        'DiffuseHorizontalIrradiance',
+        'ZenithLuminance',
+        'WindDirection',
+        'WindSpeed',
+        'Visibility',
+        'CeilingHeight',
+        'PrecipitableWater',
+        'SnowDepth',
+        'LiquidPrecipitationDepth',
+        'DaysSinceLastSnowfall'
+        )
+    BASETYPES = (
+        Temperature(),
+        Percentage(),
+        Distance(),
+        Pressure(),
+        Energy(),
+        EnergyIntensity(),
+        Power(),
+        EnergyFlux(),
+        Illuminance(),
+        Luminance(),
+        Angle(),
+        Mass(),
+        Speed(),
+        VolumeFlowRate()
+    )
+
+    @classmethod
+    def all_possible_units(cls):
+        """Return a text string indicating all possible units."""
+        unit_txt = []
+        for base_d_type in cls.BASETYPES:
+            unit_list = ', '.join(base_d_type.units)
+            unit_txt.append('{}: {}'.format(base_d_type.name, unit_list))
+        return '\n'.join(unit_txt)
+
+    @classmethod
+    def type_by_name(cls, type_name):
+        """Return a class instance of a given data type using the name of the type.
+
+        The type_name can be either the class name or the name property of the type.
+        """
+        assert isinstance(type_name, str), \
+            'type_name must be a text string got {}'.format(type(type_name))
+        data_types = cls.TYPES
+        formatted_name = type_name.title().replace(' ', '')
+        d_type = None
+        if type_name in data_types:
+            statement = 'd_type = {}()'.format(type_name)
             exec(statement)
-        return self.Pa_to_inHg(values)
+        elif formatted_name in data_types:
+            statement = 'd_type = {}()'.format(formatted_name)
+            exec(statement)
+        return d_type
 
-    def to_si(self, values, unit='inHg'):
-        """Return a list of values in Pa given the input unit."""
-        self.is_unit_acceptable(unit, True)
-        statement = 'values = self.{}_to_Pa(values)'.format(unit)
-        exec(statement)
-        return values
+    @classmethod
+    def type_by_unit(cls, unit_name):
+        """Return a class instance of a given data type using the name of the unit.
+
+        Note this method can only return fundamental classes (those that inherit
+        directly from DataTypeBase).
+        """
+        assert isinstance(unit_name, str), \
+            'unit_name must be a text string got {}'.format(type(unit_name))
+        d_type = None
+        for base_d_type in cls.BASETYPES:
+            if unit_name in base_d_type.units:
+                d_type = copy.deepcopy(base_d_type)
+        return d_type
+
+    @classmethod
+    def type_by_name_and_unit(cls, type_name, unit=None):
+        """Return a class instance of a given data type using the tpye_name and unit.
+
+        This method will always return a DataType object.  If an existing one cannot be
+        found by name, it will be found by unit, and if neither methods find an
+        existing DataType, a generic one will be returned.
+        """
+        d_type = cls.type_by_name(type_name)
+        if d_type:
+            d_type.is_unit_acceptable(unit, True)
+            return d_type
+        elif unit:
+            d_type = cls.type_by_unit(unit)
+            if d_type:
+                d_type.name = type_name
+                return d_type
+            else:
+                return GenericType(type_name, unit)
+        else:
+            return Unitless(type_name)
+
+    def ToString(self):
+        """Overwrite .NET ToString."""
+        return self.__repr__()
+
+    def __repr__(self):
+        """DataTypes representation."""
+        types = ('{}'.format(key) for key in self.TYPES)
+        return '\n'.join(types)

--- a/ladybug/datatypenew.py
+++ b/ladybug/datatypenew.py
@@ -261,13 +261,13 @@ class GenericType(DataTypeBase):
         self.name = name
         self.units = [unit]
 
-    def to_ip(self, values):
+    def to_ip(self, values, from_unit):
         """Return values in IP."""
-        return values, self.units[0]
+        return values, from_unit
 
-    def to_si(self, values, from_unit='F'):
+    def to_si(self, values, from_unit):
         """Return values in SI."""
-        return values, self.units[0]
+        return values, from_unit
 
 
 class Temperature(DataTypeBase):
@@ -288,17 +288,20 @@ class Temperature(DataTypeBase):
     def _K_to_C(self, value):
         return value - 273.15
 
-    def to_unit(self, values, unit, from_unit='C'):
+    def to_unit(self, values, unit, from_unit):
         """Return values in a given unit given the input from_unit."""
         return self._to_unit_base('C', values, unit, from_unit)
 
-    def to_ip(self, values, from_unit='C'):
-        """Return values in F given the input from_unit."""
+    def to_ip(self, values, from_unit):
+        """Return values in IP given the input from_unit."""
         return self.to_unit(values, 'F', from_unit), 'F'
 
-    def to_si(self, values, from_unit='F'):
-        """Return values in C given the input from_unit."""
-        return self.to_unit(values, 'C', from_unit), 'C'
+    def to_si(self, values, from_unit):
+        """Return values in SI given the input from_unit."""
+        if from_unit == 'C' or from_unit == 'K':
+            return values, from_unit
+        else:
+            return self.to_unit(values, 'C', from_unit), 'C'
 
     @property
     def isTemperature(self):
@@ -329,17 +332,17 @@ class Percentage(DataTypeBase):
     def _thousandths_to_pct(self, value):
         return value / 10
 
-    def to_unit(self, values, unit, from_unit='%'):
+    def to_unit(self, values, unit, from_unit):
         """Return values in a given unit given the input from_unit."""
         return self._to_unit_base('%', values, unit, from_unit)
 
-    def to_ip(self, values, from_unit='%'):
+    def to_ip(self, values, from_unit):
         """Return values in IP given the input from_unit."""
-        return self.to_unit(values, '%', from_unit), '%'
+        return values, from_unit
 
-    def to_si(self, values, from_unit='%'):
+    def to_si(self, values, from_unit):
         """Return values in SI given the input from_unit."""
-        return self.to_unit(values, '%', from_unit), '%'
+        return values, from_unit
 
     @property
     def isPercentage(self):
@@ -389,24 +392,30 @@ class Distance(DataTypeBase):
     def _cm_to_m(self, value):
         return value / 100
 
-    def to_unit(self, values, unit, from_unit='m'):
+    def to_unit(self, values, unit, from_unit):
         """Return values in a given unit given the input from_unit."""
         return self._to_unit_base('m', values, unit, from_unit)
 
-    def to_ip(self, values, from_unit='m'):
+    def to_ip(self, values, from_unit):
         """Return values in IP given the input from_unit."""
-        if from_unit == 'mm' or from_unit == 'in':
+        ip_units = ['ft', 'in', 'mi']
+        if from_unit in ip_units:
+            return values, from_unit
+        elif from_unit == 'mm':
             return self.to_unit(values, 'in', from_unit), 'in'
-        elif from_unit == 'km' or from_unit == 'mi':
+        elif from_unit == 'km':
             return self.to_unit(values, 'mi', from_unit), 'mi'
         else:
             return self.to_unit(values, 'ft', from_unit), 'ft'
 
-    def to_si(self, values, from_unit='ft'):
+    def to_si(self, values, from_unit):
         """Return values in SI given the input from_unit."""
-        if from_unit == 'in' or from_unit == 'mm':
+        si_units = ['m', 'mm', 'km', 'cm']
+        if from_unit in si_units:
+            return values, from_unit
+        elif from_unit == 'in':
             return self.to_unit(values, 'mm', from_unit), 'mm'
-        elif from_unit == 'mi' or from_unit == 'km':
+        elif from_unit == 'mi':
             return self.to_unit(values, 'km', from_unit), 'km'
         else:
             return self.to_unit(values, 'm', from_unit), 'm'
@@ -458,17 +467,25 @@ class Pressure(DataTypeBase):
     def _inH2O_to_Pa(self, value):
         return value / 0.00401865
 
-    def to_unit(self, values, unit, from_unit='Pa'):
+    def to_unit(self, values, unit, from_unit):
         """Return values in a given unit given the input from_unit."""
         return self._to_unit_base('Pa', values, unit, from_unit)
 
-    def to_ip(self, values, from_unit='Pa'):
-        """Return values in inHg given the input from_unit."""
-        return self.to_unit(values, 'inHg', from_unit), 'inHg'
+    def to_ip(self, values, from_unit):
+        """Return values in IP given the input from_unit."""
+        ip_units = ['inHg', 'psi', 'inH2O']
+        if from_unit in ip_units:
+            return values, from_unit
+        else:
+            return self.to_unit(values, 'inHg', from_unit), 'inHg'
 
-    def to_si(self, values, from_unit='inHg'):
-        """Return values in Pa given the input from_unit."""
-        return self.to_unit(values, 'Pa', from_unit), 'Pa'
+    def to_si(self, values, from_unit):
+        """Return values in SI given the input from_unit."""
+        si_units = ['Pa', 'bar']
+        if from_unit in si_units:
+            return values, from_unit
+        else:
+            return self.to_unit(values, 'Pa', from_unit), 'Pa'
 
     @property
     def isPressure(self):
@@ -479,7 +496,7 @@ class Pressure(DataTypeBase):
 class Energy(DataTypeBase):
     """Energy"""
     name = 'Energy'
-    units = ['kWh', 'kBtu', 'Wh', 'Btu', 'MMBtu', 'J', 'kJ', 'GJ',
+    units = ['kWh', 'kBtu', 'Wh', 'Btu', 'MMBtu', 'J', 'kJ', 'MJ', 'GJ',
              'therm', 'cal', 'kcal']
     cumulative = True
 
@@ -501,8 +518,11 @@ class Energy(DataTypeBase):
     def _kWh_to_kJ(self, value):
         return value * 3600
 
-    def _kWh_to_GJ(self, value):
+    def _kWh_to_MJ(self, value):
         return value * 3.6
+
+    def _kWh_to_GJ(self, value):
+        return value * 0.0036
 
     def _kWh_to_therm(self, value):
         return value * 0.0341214
@@ -531,8 +551,11 @@ class Energy(DataTypeBase):
     def _kJ_to_kWh(self, value):
         return value / 3600
 
-    def _GJ_to_kWh(self, value):
+    def _MJ_to_kWh(self, value):
         return value / 3.6
+
+    def _GJ_to_kWh(self, value):
+        return value / 0.0036
 
     def _therm_to_kWh(self, value):
         return value / 0.0341214
@@ -543,20 +566,26 @@ class Energy(DataTypeBase):
     def _kcal_to_kWh(self, value):
         return value / 860.421
 
-    def to_unit(self, values, unit, from_unit='kWh'):
+    def to_unit(self, values, unit, from_unit):
         """Return values in a given unit given the input from_unit."""
         return self._to_unit_base('kWh', values, unit, from_unit)
 
-    def to_ip(self, values, from_unit='kWh'):
+    def to_ip(self, values, from_unit):
         """Return values in IP given the input from_unit."""
-        if from_unit == 'Wh' or from_unit == 'Btu':
+        ip_units = ['kBtu', 'Btu', 'MMBtu', 'therm']
+        if from_unit in ip_units:
+            return values, from_unit
+        elif from_unit == 'Wh':
             return self.to_unit(values, 'Btu', from_unit), 'Btu'
         else:
             return self.to_unit(values, 'kBtu', from_unit), 'kBtu'
 
-    def to_si(self, values, from_unit='kBtu'):
+    def to_si(self, values, from_unit):
         """Return values in SI given the input from_unit."""
-        if from_unit == 'Btu' or from_unit == 'Wh':
+        si_units = ['kWh', 'Wh', 'J', 'kJ', 'MJ', 'GJ']
+        if from_unit in si_units:
+            return values, from_unit
+        elif from_unit == 'Btu':
             return self.to_unit(values, 'Wh', from_unit), 'Wh'
         else:
             return self.to_unit(values, 'kWh', from_unit), 'kWh'
@@ -591,20 +620,26 @@ class EnergyIntensity(DataTypeBase):
     def _Btu_ft2_to_kWh_m2(self, value):
         return value / 316.998
 
-    def to_unit(self, values, unit, from_unit='kWh/m2'):
+    def to_unit(self, values, unit, from_unit):
         """Return values in a given unit given the input from_unit."""
         return self._to_unit_base('kWh/m2', values, unit, from_unit)
 
-    def to_ip(self, values, from_unit='kWh/m2'):
+    def to_ip(self, values, from_unit):
         """Return values in IP given the input from_unit."""
-        if from_unit == 'Wh/m2' or from_unit == 'Btu/ft2':
+        ip_units = ['kBtu/ft2', 'Btu/ft2']
+        if from_unit in ip_units:
+            return values, from_unit
+        elif from_unit == 'Wh/m2':
             return self.to_unit(values, 'Btu/ft2', from_unit), 'Btu/ft2'
         else:
             return self.to_unit(values, 'kBtu/ft2', from_unit), 'kBtu/ft2'
 
-    def to_si(self, values, from_unit='kBtu/ft2'):
+    def to_si(self, values, from_unit):
         """Return values in SI given the input from_unit."""
-        if from_unit == 'Btu/ft2' or from_unit == 'Wh/m2':
+        si_units = ['kWh/m2', 'Wh/m2']
+        if from_unit in si_units:
+            return values, from_unit
+        elif from_unit == 'Btu/ft2':
             return self.to_unit(values, 'Wh/m2', from_unit), 'Wh/m2'
         else:
             return self.to_unit(values, 'kWh/m2', from_unit), 'kWh/m2'
@@ -650,20 +685,26 @@ class Power(DataTypeBase):
     def _hp_to_W(self, value):
         return value * 745.7
 
-    def to_unit(self, values, unit, from_unit='W'):
+    def to_unit(self, values, unit, from_unit):
         """Return values in a given unit given the input from_unit."""
         return self._to_unit_base('W', values, unit, from_unit)
 
-    def to_ip(self, values, from_unit='W'):
+    def to_ip(self, values, from_unit):
         """Return values in IP given the input from_unit."""
-        if from_unit == 'kW' or from_unit == 'kBtu/h':
+        ip_units = ['Btu/h', 'kBtu/h', 'TR', 'hp']
+        if from_unit in ip_units:
+            return values, from_unit
+        elif from_unit == 'kW':
             return self.to_unit(values, 'kBtu/h', from_unit), 'kBtu/h'
         else:
             return self.to_unit(values, 'Btu/h', from_unit), 'Btu/h'
 
-    def to_si(self, values, from_unit='Btu/h'):
+    def to_si(self, values, from_unit):
         """Return values in SI given the input from_unit."""
-        if from_unit == 'kBtu/h' or from_unit == 'kW':
+        si_units = ['kW', 'W']
+        if from_unit in si_units:
+            return values, from_unit
+        elif from_unit == 'kBtu/h':
             return self.to_unit(values, 'kW', from_unit), 'kW'
         else:
             return self.to_unit(values, 'W', from_unit), 'W'
@@ -703,20 +744,26 @@ class EnergyFlux(DataTypeBase):
     def _W_ft2_to_W_m2(self, value):
         return value * 10.7639
 
-    def to_unit(self, values, unit, from_unit='W/m2'):
+    def to_unit(self, values, unit, from_unit):
         """Return values in a given unit given the input from_unit."""
         return self._to_unit_base('W/m2', values, unit, from_unit)
 
-    def to_ip(self, values, from_unit='W/m2'):
+    def to_ip(self, values, from_unit):
         """Return values in IP given the input from_unit."""
-        if from_unit == 'kW/m2' or from_unit == 'kBtu/h-ft2':
+        ip_units = ['Btu/h-ft2', 'kBtu/h-ft2']
+        if from_unit in ip_units:
+            return values, from_unit
+        elif from_unit == 'kW/m2':
             return self.to_unit(values, 'kBtu/h-ft2', from_unit), 'kBtu/h-ft2'
         else:
             return self.to_unit(values, 'Btu/h-ft2', from_unit), 'Btu/h-ft2'
 
-    def to_si(self, values, from_unit='Btu/h-ft2'):
+    def to_si(self, values, from_unit):
         """Return values in SI given the input from_unit."""
-        if from_unit == 'kBtu/h-ft2' or from_unit == 'kW/m2':
+        si_units = ['W/m2', 'kW/m2']
+        if from_unit in si_units:
+            return values, from_unit
+        elif from_unit == 'kBtu/h-ft2':
             return self.to_unit(values, 'kW/m2', from_unit), 'kW/m2'
         else:
             return self.to_unit(values, 'W/m2', from_unit), 'W/m2'
@@ -741,15 +788,15 @@ class Illuminance(DataTypeBase):
     def _fc_to_lux(self, value):
         return value * 10.7639
 
-    def to_unit(self, values, unit, from_unit='lux'):
+    def to_unit(self, values, unit, from_unit):
         """Return values in a given unit given the input from_unit."""
         return self._to_unit_base('lux', values, unit, from_unit)
 
-    def to_ip(self, values, from_unit='lux'):
+    def to_ip(self, values, from_unit):
         """Return values in fc given the input from_unit."""
         return self.to_unit(values, 'fc', from_unit), 'fc'
 
-    def to_si(self, values, from_unit='fc'):
+    def to_si(self, values, from_unit):
         """Return values in lux given the input from_unit."""
         return self.to_unit(values, 'lux', from_unit), 'lux'
 
@@ -773,15 +820,15 @@ class Luminance(DataTypeBase):
     def _cd_ft2_to_cd_m2(self, value):
         return value * 10.7639
 
-    def to_unit(self, values, unit, from_unit='cd/m2'):
+    def to_unit(self, values, unit, from_unit):
         """Return values in a given unit given the input from_unit."""
         return self._to_unit_base('cd/m2', values, unit, from_unit)
 
-    def to_ip(self, values, from_unit='cd/m2'):
+    def to_ip(self, values, from_unit):
         """Return values in cd/ft2 given the input from_unit."""
         return self.to_unit(values, 'cd/ft2', from_unit), 'cd/ft2'
 
-    def to_si(self, values, from_unit='cd/ft2'):
+    def to_si(self, values, from_unit):
         """Return values in cd/m2 given the input from_unit."""
         return self.to_unit(values, 'cd/m2', from_unit), 'cd/m2'
 
@@ -802,15 +849,15 @@ class Angle(DataTypeBase):
     def _radians_to_degrees(self, value):
         return (value / PI) * 180
 
-    def to_unit(self, values, unit, from_unit='degrees'):
+    def to_unit(self, values, unit, from_unit):
         """Return values in a given unit given the input from_unit."""
         return self._to_unit_base('degrees', values, unit, from_unit)
 
-    def to_ip(self, values, from_unit='degrees'):
+    def to_ip(self, values, from_unit):
         """Return values in IP."""
         return values, from_unit
 
-    def to_si(self, values, from_unit='degrees'):
+    def to_si(self, values, from_unit):
         """Return values in SI."""
         return values, from_unit
 
@@ -823,7 +870,7 @@ class Angle(DataTypeBase):
 class Mass(DataTypeBase):
     """Mass"""
     name = 'Mass'
-    units = ['kg', 'lb', 'g', 'tonne']
+    units = ['kg', 'lb', 'g', 'tonne', 'ton']
     min = 0
 
     def _kg_to_lb(self, value):
@@ -835,6 +882,9 @@ class Mass(DataTypeBase):
     def _kg_to_tonne(self, value):
         return value / 1000
 
+    def _kg_to_ton(self, value):
+        return value / 907.185
+
     def _lb_to_kg(self, value):
         return value / 2.20462
 
@@ -844,17 +894,32 @@ class Mass(DataTypeBase):
     def _tonne_to_kg(self, value):
         return value * 1000
 
-    def to_unit(self, values, unit, from_unit='kg'):
+    def _ton_to_kg(self, value):
+        return value * 907.185
+
+    def to_unit(self, values, unit, from_unit):
         """Return values in a given unit given the input from_unit."""
         return self._to_unit_base('kg', values, unit, from_unit)
 
-    def to_ip(self, values, from_unit='kg'):
-        """Return values in lb given the input from_unit."""
-        return self.to_unit(values, 'lb', from_unit), 'lb'
+    def to_ip(self, values, from_unit):
+        """Return values in IP given the input from_unit."""
+        ip_units = ['lb', 'ton']
+        if from_unit in ip_units:
+            return values, from_unit
+        elif from_unit == 'tonne':
+            return self.to_unit(values, 'ton', from_unit), 'ton'
+        else:
+            return self.to_unit(values, 'lb', from_unit), 'lb'
 
-    def to_si(self, values, from_unit='lb'):
-        """Return values in kg given the input from_unit."""
-        return self.to_unit(values, 'kg', from_unit), 'kg'
+    def to_si(self, values, from_unit):
+        """Return values in SI given the input from_unit."""
+        si_units = ['kg', 'g', 'tonne']
+        if from_unit in si_units:
+            return values, from_unit
+        elif from_unit == 'ton':
+            return self.to_unit(values, 'tonne', from_unit), 'tonne'
+        else:
+            return self.to_unit(values, 'kg', from_unit), 'kg'
 
     @property
     def isMass(self):
@@ -892,17 +957,25 @@ class Speed(DataTypeBase):
     def _ft_s_to_m_s(self, value):
         return value / 3.28084
 
-    def to_unit(self, values, unit, from_unit='m/s'):
+    def to_unit(self, values, unit, from_unit):
         """Return values in a given unit given the input from_unit."""
         return self._to_unit_base('m/s', values, unit, from_unit)
 
-    def to_ip(self, values, from_unit='m/s'):
-        """Return values in mph given the input from_unit."""
-        return self.to_unit(values, 'mph', from_unit), 'mph'
+    def to_ip(self, values, from_unit):
+        """Return values in IP units given the input from_unit."""
+        ip_units = ['mph', 'ft/s']
+        if from_unit in ip_units:
+            return values, from_unit
+        else:
+            return self.to_unit(values, 'mph', from_unit), 'mph'
 
-    def to_si(self, values, from_unit='mph'):
-        """Return values in m/s given the input from_unit."""
-        return self.to_unit(values, 'm/s', from_unit), 'm/s'
+    def to_si(self, values, from_unit):
+        """Return values in SI units given the input from_unit."""
+        si_units = ['m/s', 'km/h']
+        if from_unit in si_units:
+            return values, from_unit
+        else:
+            return self.to_unit(values, 'm/s', from_unit), 'm/s'
 
     @property
     def isSpeed(self):
@@ -940,17 +1013,29 @@ class VolumeFlowRate(DataTypeBase):
     def _gpm_to_m3_s(self, value):
         return value / 15850.3231
 
-    def to_unit(self, values, unit, from_unit='m3/s'):
+    def to_unit(self, values, unit, from_unit):
         """Return values in a given unit given the input from_unit."""
         return self._to_unit_base('m3/s', values, unit, from_unit)
 
-    def to_ip(self, values, from_unit='m3/s'):
-        """Return values in mph given the input from_unit."""
-        return self.to_unit(values, 'ft3/s', from_unit), 'ft3/s'
+    def to_ip(self, values, from_unit):
+        """Return values in IP units given the input from_unit."""
+        ip_units = ['ft3/s', 'cfm', 'gpm']
+        if from_unit in ip_units:
+            return values, from_unit
+        elif from_unit == 'L/s':
+            return self.to_unit(values, 'cfm', from_unit), 'cfm'
+        else:
+            return self.to_unit(values, 'ft3/s', from_unit), 'ft3/s'
 
-    def to_si(self, values, from_unit='ft3/s'):
-        """Return values in m/s given the input from_unit."""
-        return self.to_unit(values, 'm3/s', from_unit), 'm3/s'
+    def to_si(self, values, from_unit):
+        """Return values in SI units given the input from_unit."""
+        si_units = ['m3/s', 'L/s']
+        if from_unit in si_units:
+            return values, from_unit
+        elif from_unit == 'cfm':
+            return self.to_unit(values, 'L/s', from_unit), 'L/s'
+        else:
+            return self.to_unit(values, 'm3/s', from_unit), 'm3/s'
 
     @property
     def isFlowRate(self):

--- a/ladybug/datatypenew.py
+++ b/ladybug/datatypenew.py
@@ -1,4 +1,6 @@
 """Ladybug data types."""
+from ladybug.datatype import DataPoint
+
 import copy
 import math
 
@@ -191,7 +193,7 @@ class DataTypeBase(object):
     def _check_values(self, values):
         """Check to be sure values are numbers before doing numerical operations."""
         if len(values) > 0:
-            assert isinstance(values[0], (float, int)), \
+            assert isinstance(values[0], (float, int, DataPoint)), \
                 "values must be numbers to perform math operations. Got {}".format(
                     type(values[0]))
 

--- a/ladybug/datatypenew.py
+++ b/ladybug/datatypenew.py
@@ -1067,6 +1067,11 @@ class DiffuseHorizontalRadiation(Radiation):
     middle_hour_epw = True
 
 
+class DirectHorizontalRadiation(Radiation):
+    name = 'Direct Horizontal Radiation'
+    middle_hour_epw = True
+
+
 class HorizontalInfraredRadiationIntensity(Radiation):
     name = 'Horizontal Infrared Radiation Intensity'
 
@@ -1105,6 +1110,11 @@ class DirectNormalIrradiance(Irradiance):
 
 class DiffuseHorizontalIrradiance(Irradiance):
     name = 'Diffuse Horizontal Irradiance'
+    middle_hour_epw = True
+
+
+class DirectHorizontalIrradiance(Irradiance):
+    name = 'Direct Horizontal Irradiance'
     middle_hour_epw = True
 
 
@@ -1208,6 +1218,7 @@ class DataTypes(object):
         'GlobalHorizontalRadiation',
         'DirectNormalRadiation',
         'DiffuseHorizontalRadiation',
+        'DirectHorizontalRadiation',
         'HorizontalInfraredRadiationIntensity',
         'ExtraterrestrialHorizontalRadiation',
         'ExtraterrestrialDirectNormalRadiation',
@@ -1215,6 +1226,7 @@ class DataTypes(object):
         'GlobalHorizontalIrradiance',
         'DirectNormalIrradiance',
         'DiffuseHorizontalIrradiance',
+        'DirectHorizontalIrradiance',
         'ZenithLuminance',
         'WindDirection',
         'WindSpeed',

--- a/ladybug/datatypenew.py
+++ b/ladybug/datatypenew.py
@@ -1,0 +1,319 @@
+"""Ladybug data types."""
+import math
+from .euclid import Vector3
+
+PI = math.pi
+
+
+class DataTypes(object):
+    """Available data type classes organized by full name of the data type."""
+    TYPES = {
+        'Generic Type': 'DataTypeBase',
+        'Temperature': 'Temperature',
+        'Dry Bulb Temperature': 'DryBulbTemperature',
+        'Dew Point Temperature': 'DewPointTemperature',
+        'Sky Temperature': 'SkyTemperature',
+        'Mean Radiant Temperature': 'MeanRadiantTemperature',
+        'Relative Humidity': 'RelativeHumidity',
+        }
+
+    @classmethod
+    def type_by_name(cls, type_name):
+        """Return the name of the class using the name of the data type."""
+        assert isinstance(type_name, str), \
+            'type_name must be a text string got {}'.format(type(type_name))
+        data_types = cls.TYPES
+        if type_name.title() in data_types.keys():
+            d_type = None
+            statement = 'd_type = {}()'.format(data_types[type_name.title()])
+            exec(statement)
+            return d_type
+        else:
+            return GenericType(type_name.title())
+
+    def ToString(self):
+        """Overwrite .NET ToString."""
+        return self.__repr__()
+
+    def __repr__(self):
+        """DataTypes representation."""
+        types = ('{}'.format(key) for key in self.TYPES.keys())
+        return '\n'.join(types)
+
+
+class DataTypeBase(object):
+    """Base type for data types.
+
+    Attributes:
+        name: The full name of the data type as a string.
+        units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if such exist).
+            The rest of the list should be any other acceptable units.
+            (eg. [C, F, K])
+        min: Optional lower value for the data type.
+        max: Optional upper value for the data type.
+        missing: Optional missing value for the data type.
+        unit_descr: An optional description of the units if the numerical values
+            of these units relate to specific categories.
+            (eg. -1 = Cold, 0 = Neutral, +1 = Hot) (eg. 0 = False, 1 = True)
+        cumulative: Boolean value to tell whether the value is cumulative over
+            a time period or represents conditions at an instant in time
+            (or an average over a time period). The default is False.
+    """
+
+    name = 'Generic Type'
+    units = [None]
+    min = float('-inf')
+    max = float('+inf')
+    missing = None
+    unit_descr = ''
+    cumulative = False
+
+    def __init__(self):
+        """Init DataType."""
+
+    @classmethod
+    def from_json(cls, data):
+        """Create a data type from a dictionary.
+
+        Args:
+            data: Data as a dictionary.
+                {
+                    "name": data type name as a string
+                }
+        """
+        assert 'name' in data, 'Required keyword "name" is missing!'
+        return DataTypes.type_by_name(data['name'])
+
+    def is_unit_acceptable(self, unit, raise_exception=False):
+        """Check if a certain unit is acceptable for the data type.
+
+        Args:
+            unit: A text string representing the abbreviated unit.
+            raise_exception: Set to True to raise an exception if not acceptable.
+        """
+        _is_acceptable = unit in self.units
+
+        if _is_acceptable or raise_exception is False:
+            return _is_acceptable
+        else:
+            raise ValueError(
+                '{0} is not an acceptable unit type for {1}. '
+                'Choose from the following: {2}'.format(
+                    unit, self.__class__.__name__, self.units
+                )
+            )
+
+    def to_ip(self, data):
+        """Method that converts a list of values from SI to IP."""
+        raise NotImplementedError(
+            'to_ip is not implemented on %s' % self.__class__.__name__
+        )
+
+    def to_si(self, data):
+        """Method that converts a list of values from IP to SI."""
+        raise NotImplementedError(
+            'to_si is not implemented on %s' % self.__class__.__name__
+        )
+
+    def is_missing(self, values):
+        """Check if a list of values contains missing data."""
+        for value in values:
+            if value == self.missing:
+                return True
+        return False
+
+    def is_in_range(self, values, unit=None, raise_exception=False):
+        """check if a list of values is within acceptable ranges.
+
+        Args:
+            values: A list of values.
+            unit: The unit of the values.  If not specified, the default metric
+                unit will be assumed.
+            raise_exception: Set to True to raise an exception if not in range.
+        """
+        if unit is None or unit == self.units[0]:
+            minimum = self.min
+            maximum = self.max
+        else:
+            self.is_unit_acceptable(unit, True)
+            min_statement = "minimum = self.{}_to_{}(self.min)".format(
+                self.units[0], unit)
+            max_statement = "maximum = self.{}_to_{}(self.max)".format(
+                self.units[0], unit)
+            exec(min_statement)
+            exec(max_statement)
+
+        for value in values:
+            if value == self.missing:
+                continue
+            if value < minimum or value > maximum:
+                if not raise_exception:
+                    return False
+                else:
+                    raise ValueError(
+                        '{0} should be between {1} and {2}. Got {3}'.format(
+                            self.__class__.__name__, self.min, self.max, value
+                        )
+                    )
+        return True
+
+    def to_json(self):
+        "Get data type as a json object"
+        return {
+            'name': self.name
+        }
+
+    @property
+    def isDataType(self):
+        """Return True."""
+        return True
+
+    def ToString(self):
+        """Overwrite .NET ToString."""
+        return self.__repr__()
+
+    def __repr__(self):
+        """Return Ladybug data type as a string."""
+        return self.name
+
+
+class GenericType(DataTypeBase):
+    """Type for any data without a recognizable name."""
+    def __init__(self, name):
+        """Init Generic Type."""
+        self.name = name
+
+
+class Temperature(DataTypeBase):
+    """Temperature."""
+    name = 'Temperature'
+    units = ['C', 'F', 'K']
+    min = -273.15
+
+    def C_to_F(self, values):
+        """Return a list of values in F assuming input values are in C."""
+        return [value * 9 / 5 + 32 for value in values]
+
+    def C_to_K(self, values):
+        """Return a list of values in K assuming input values are in C."""
+        return [value + 273.15 for value in values]
+
+    def F_to_C(self, values):
+        """Return a list of values in C assuming input values are in F."""
+        return [(value - 32) * 5 / 9 for value in values]
+
+    def K_to_C(self, values):
+        """Return a list of values in K assuming input values are in C."""
+        return [value - 273.15 for value in values]
+
+    def to_ip(self, values, unit='C'):
+        """Return a list of values in F given the input unit."""
+        if not unit == 'C':
+            self.is_unit_acceptable(unit, True)
+            statement = 'values = self.{}_to_C(values)'.format(unit)
+            exec(statement)
+        return self.C_to_F(values)
+
+    def to_si(self, values, unit='F'):
+        """Return a list of values in C given the input unit."""
+        self.is_unit_acceptable(unit, True)
+        statement = 'values = self.{}_to_C(values)'.format(unit)
+        exec(statement)
+        return values
+
+    @property
+    def isTemperature(self):
+        """Return True."""
+        return True
+
+
+class DryBulbTemperature(Temperature):
+    """Dry Bulb Temperature."""
+    name = 'Dry Bulb Temperature'
+    missing = 99.9
+
+
+class DewPointTemperature(Temperature):
+    """Dew Point Temperature."""
+    name = 'Dew Point Temperature'
+    missing = 99.9
+
+
+class SkyTemperature(Temperature):
+    """Sky Temperature."""
+    name = 'Sky Temperature'
+    missing = 99.9
+
+
+class MeanRadiantTemperature(Temperature):
+    """Mean Radiant Temperature."""
+    name = 'Mean Radiant Temperature'
+
+
+class RelativeHumidity(DataTypeBase):
+    """Relative Humidity."""
+    name = 'Relative Humidity'
+    units = ['%']
+    min = 0
+    max = 100
+    missing = 999
+
+    def to_ip(self, values):
+        """Return the value in IP."""
+        return values
+
+    def to_si(self, values):
+        """Return the value in SI."""
+        return values
+
+    @property
+    def isRelativeHumidity(self):
+        """Return True."""
+        return True
+
+
+class Pressure(DataTypeBase):
+    """Pressure"""
+    name = 'Pressure'
+    units = ['Pa', 'inHg', 'atm', 'bar', 'Torr', 'psi', 'inH2O', 'kPa']
+
+    def Pa_to_inHg(self, values):
+        """Return the value in inHg given an input in Pa."""
+        return [value * 0.0002953 for value in values]
+
+    def Pa_to_atm(self, values):
+        """Return the value in atm given an input in Pa."""
+        return [value / 101325 for value in values]
+
+    def Pa_to_bar(self, values):
+        """Return the value in bat given an input in Pa."""
+        return [value / 100000 for value in values]
+
+    def inHg_to_Pa(self, values):
+        """Return the value in Pa given an input in inHg."""
+        return [value / 0.0002953 for value in values]
+
+    def atm_to_Pa(self, values):
+        """Return the value in atm given an input in Pa."""
+        return [value * 101325 for value in values]
+
+    def bar_to_Pa(self, values):
+        """Return the value in bar given an input in Pa."""
+        return [value * 100000 for value in values]
+
+    def to_ip(self, values, unit='Pa'):
+        """Return a list of values in inHg given the input unit."""
+        if not unit == 'Pa':
+            self.is_unit_acceptable(unit, True)
+            statement = 'values = self.{}_to_Pa(values)'.format(unit)
+            exec(statement)
+        return self.Pa_to_inHg(values)
+
+    def to_si(self, values, unit='inHg'):
+        """Return a list of values in Pa given the input unit."""
+        self.is_unit_acceptable(unit, True)
+        statement = 'values = self.{}_to_Pa(values)'.format(unit)
+        exec(statement)
+        return values

--- a/ladybug/datatypenew.py
+++ b/ladybug/datatypenew.py
@@ -106,11 +106,10 @@ class DataTypeBase(object):
             'to_si is not implemented on %s' % self.__class__.__name__
         )
 
-    def is_missing(self, values):
-        """Check if a list of values contains missing data when in an EPW."""
-        for value in values:
-            if value == self.missing_epw:
-                return True
+    def is_missing(self, value):
+        """Check if a value contains missing data when in an EPW."""
+        if value == self.missing_epw:
+            return True
         return False
 
     def is_in_range(self, values, unit=None, raise_exception=False):
@@ -127,13 +126,15 @@ class DataTypeBase(object):
             minimum = self.min
             maximum = self.max
         else:
+            namespace = {'self': self, 'minimum': None, 'maximum': None}
             self.is_unit_acceptable(unit, True)
-            min_statement = "minimum = self.{}_to_{}(self.min)".format(
+            min_statement = "minimum = self._{}_to_{}(self.min)".format(
                 self._clean(self.units[0]), self._clean(unit))
-            max_statement = "maximum = self.{}_to_{}(self.max)".format(
+            max_statement = "maximum = self._{}_to_{}(self.max)".format(
                 self._clean(self.units[0]), self._clean(unit))
-            exec(min_statement)
-            exec(max_statement)
+            exec(min_statement, namespace)
+            exec(max_statement, namespace)
+            minimum, maximum = namespace['minimum'], namespace['maximum']
 
         for value in values:
             if value < minimum or value > maximum:
@@ -147,7 +148,7 @@ class DataTypeBase(object):
                     )
         return True
 
-    def is_in_epw_range(self, values, unit=None, raise_exception=False):
+    def is_in_range_epw(self, values, unit=None, raise_exception=False):
         """Check if a list of values is within acceptable ranges for an EPW file.
 
         Args:
@@ -161,13 +162,15 @@ class DataTypeBase(object):
             minimum = self.min_epw
             maximum = self.max_epw
         else:
+            namespace = {'self': self, 'minimum': None, 'maximum': None}
             self.is_unit_acceptable(unit, True)
-            min_statement = "minimum = self.{}_to_{}(self.min_epw)".format(
+            min_statement = "minimum = self._{}_to_{}(self.min_epw)".format(
                 self._clean(self.units[0]), self._clean(unit))
-            max_statement = "maximum = self.{}_to_{}(self.max_epw)".format(
+            max_statement = "maximum = self._{}_to_{}(self.max_epw)".format(
                 self._clean(self.units[0]), self._clean(unit))
-            exec(min_statement)
-            exec(max_statement)
+            exec(min_statement, namespace)
+            exec(max_statement, namespace)
+            minimum, maximum = namespace['minimum'], namespace['maximum']
 
         for value in values:
             if self.is_missing(value):

--- a/ladybug/datatypenew.py
+++ b/ladybug/datatypenew.py
@@ -36,9 +36,6 @@ class DataTypeBase(object):
             found in an EPW file. (Default: False).
     """
 
-    __slots__ = ('name', 'units', 'min', 'max', 'unit_descr', 'cumulative',
-                 'min_epw', 'max_epw', 'missing_epw', 'middle_hour_epw')
-
     name = 'Data Type Base'
     units = [None]
     min = float('-inf')

--- a/ladybug/designday.py
+++ b/ladybug/designday.py
@@ -589,7 +589,9 @@ class DesignDay(object):
     def _get_daily_data_collections(self, data_type, unit, data=None):
         """Return an empty data collection.
         """
-        data_header = Header(self._location, data_type, unit, self.analysis_period)
+        data_header = Header(data_type=data_type, unit=unit,
+                             analysis_period=self.analysis_period,
+                             location=self._location)
         return DataCollection(data=data, header=data_header)
 
     @property

--- a/ladybug/epw.py
+++ b/ladybug/epw.py
@@ -729,8 +729,7 @@ class EPW(object):
         # create sky temperature data collection from horizontal infrared
         horiz_ir = self._get_data_by_field(12)
         sky_temp_header = copy.copy(horiz_ir.header)
-        sky_temp_header.data_type = 'Sky Temperature'
-        sky_temp_header.unit = 'C'
+        sky_temp_header.set_data_type_and_unit('Sky Temperature', 'C')
 
         # calculate sy temperature for each hour
         sky_temp_data = []

--- a/ladybug/header.py
+++ b/ladybug/header.py
@@ -1,8 +1,7 @@
 # coding=utf-8
-"""Ladybug Header.
+"""Ladybug Header"""
+from copy import deepcopy
 
-Header is useful for creating list of ladybug data.
-"""
 from .location import Location
 from .analysisperiod import AnalysisPeriod
 from .datatypenew import DataTypes
@@ -125,9 +124,10 @@ class Header(object):
         self._unit = unit if unit else None
 
     def duplicate(self):
-        """Duplicate header."""
-        return self.__class__(self.data_type, self.unit, self.analysis_period,
-                              self.location)
+        """Return a copy of the header."""
+        return self.__class__(deepcopy(self.data_type), self.unit,
+                              AnalysisPeriod.from_string(str(self.analysis_period)),
+                              deepcopy(self.location))
 
     def to_tuple(self):
         """Return Ladybug header as a list."""

--- a/ladybug/header.py
+++ b/ladybug/header.py
@@ -25,18 +25,19 @@ class Header(object):
 
     __slots__ = ('_data_type', '_unit', '_analysis_period', '_location')
 
-    def __init__(self, data_type, unit=None,
+    def __init__(self, data_type=None, unit=None,
                  analysis_period=None, location=None):
         """Initiate Ladybug header for lists.
 
         Args:
-            data_type: A DataType object or text indicating the name of a DataType.
-                (e.g. Temperature) (Default: None).
+            data_type: A DataType object or text indicating the name of the DataType.
+                (e.g. Temperature) (Default: 'Unknown Data').
             unit: data_type unit (Default: None)
             analysis_period: A Ladybug analysis period (Defualt: None)
             location: location data as a ladybug Location or location string
                 (Default: None)
         """
+        data_type = data_type or 'Unknown Data'
         self.set_data_type_and_unit(data_type, unit)
         self.analysis_period = analysis_period
         self.location = location

--- a/ladybug/header.py
+++ b/ladybug/header.py
@@ -23,7 +23,7 @@ class Header(object):
             (Default: None).
     """
 
-    __slots__ = ('data_type', 'unit', 'analysis_period', 'location')
+    __slots__ = ('_data_type', '_unit', '_analysis_period', '_location')
 
     def __init__(self, data_type, unit=None,
                  analysis_period=None, location=None):
@@ -37,14 +37,9 @@ class Header(object):
             location: location data as a ladybug Location or location string
                 (Default: None)
         """
-        if hasattr(data_type, 'isDataType'):
-            data_type.is_unit_acceptable(unit)
-            self.data_type = data_type
-        else:
-            self.data_type = DataTypes.type_by_name_and_unit(data_type, unit)
-        self.unit = unit if unit else None
-        self.analysis_period = AnalysisPeriod.from_analysis_period(analysis_period)
-        self.location = Location.from_location(location)
+        self.set_data_type_and_unit(data_type, unit)
+        self.analysis_period = analysis_period
+        self.location = location
 
     @classmethod
     def from_json(cls, data):
@@ -84,9 +79,49 @@ class Header(object):
                 "Failed to create a Header from %s!\n%s" % (header, e))
 
     @property
+    def data_type(self):
+        """A DataType object."""
+        return self._data_type
+
+    @property
+    def unit(self):
+        """A text string representing an abbreviated unit."""
+        return self._unit
+
+    @property
+    def analysis_period(self):
+        """A AnalysisPeriod object."""
+        return self._analysis_period
+
+    @analysis_period.setter
+    def analysis_period(self, ap):
+        self._analysis_period = AnalysisPeriod.from_analysis_period(ap)
+
+    @property
+    def location(self):
+        """A Location object."""
+        return self._location
+
+    @location.setter
+    def location(self, loc):
+        self._location = Location.from_location(loc)
+
+    @property
     def isHeader(self):
         """Return True."""
         return True
+
+    def set_data_type_and_unit(self, data_type, unit):
+        """Set data_type and unit. This method should NOT be used for unit conversions.
+
+        For unit conversions, the to_unit() method should be used on the data collection.
+        """
+        if hasattr(data_type, 'isDataType'):
+            data_type.is_unit_acceptable(unit)
+            self._data_type = data_type
+        else:
+            self._data_type = DataTypes.type_by_name_and_unit(data_type, unit)
+        self._unit = unit if unit else None
 
     def duplicate(self):
         """Duplicate header."""

--- a/ladybug/location.py
+++ b/ladybug/location.py
@@ -13,15 +13,18 @@ class Location(object):
         longitude: Location longitude between -180 (west) and 180 (east) (Default: 0).
         time_zone: Time zone between -12 hours (west) and 12 hours (east) (Default: 0).
         elevation: A number for elevation of the location.
-        station_id: Id of the location if the location is represnting a weather station.
+        station_id: ID of the location if the location is represnting a weather station.
         source: Source of data (e.g. TMY, TMY3).
+        building_id: ID of the building if the data comes from a simulation.
+        zone_id: ID of the zone if the data comes from a simulation.
     """
 
     __slots__ = ("city", "country", "_lat", "_lon", "_tz", "_elev",
                  "station_id", "source")
 
     def __init__(self, city=None, country=None, latitude=0, longitude=0,
-                 time_zone=0, elevation=0, station_id=None, source=None):
+                 time_zone=0, elevation=0, station_id=None, source=None,
+                 building_id=None, zone_id=None):
         """Create a Ladybug location."""
         self.city = '-' if not city else str(city)
         self.country = '-' if not country else str(country)
@@ -31,6 +34,8 @@ class Location(object):
         self.elevation = elevation or 0
         self.station_id = None if not station_id else str(station_id)
         self.source = source
+        self.building_id = building_id
+        self.zone_id = zone_id
 
     @classmethod
     def from_json(cls, loc_json):

--- a/ladybug/location.py
+++ b/ladybug/location.py
@@ -20,7 +20,7 @@ class Location(object):
     """
 
     __slots__ = ("city", "country", "_lat", "_lon", "_tz", "_elev",
-                 "station_id", "source")
+                 "station_id", "source", "building_id", "zone_id")
 
     def __init__(self, city=None, country=None, latitude=0, longitude=0,
                  time_zone=0, elevation=0, station_id=None, source=None,

--- a/ladybug/wea.py
+++ b/ladybug/wea.py
@@ -32,22 +32,22 @@ except ImportError:
 
 
 class Wea(object):
-    """An annual WEA object containing solar radiation.
+    """An annual WEA object containing solar irradiance.
 
     Attributes:
         location: Ladybug location object.
-        direct_normal_radiation: An annual DataCollection of direct normal radiation
+        direct_normal_irradiance: An annual DataCollection of direct normal irradiance
             values.
-        diffuse_horizontal_radiation: An annual DataCollection of diffuse horizontal
-            radiation values for every hourly timestep of the year.
+        diffuse_horizontal_irradiance: An annual DataCollection of diffuse horizontal
+            irradiance values for every hourly timestep of the year.
         timestep: An optional integer to set the number of time steps per hour.
             Default is 1 for one value per hour.
         is_leap_year: A boolean to indicate if values are representing a leap year.
             Default is False.
     """
 
-    def __init__(self, location, direct_normal_radiation,
-                 diffuse_horizontal_radiation, timestep=1, is_leap_year=False):
+    def __init__(self, location, direct_normal_irradiance,
+                 diffuse_horizontal_irradiance, timestep=1, is_leap_year=False):
         """Create a wea object."""
         timestep = timestep or 1
         self._timestep = timestep
@@ -56,38 +56,40 @@ class Wea(object):
             ' integer. Got {}'.format(type(timestep))
 
         self.location = location
-        self.direct_normal_radiation = direct_normal_radiation
-        self.diffuse_horizontal_radiation = diffuse_horizontal_radiation
+        self.direct_normal_irradiance = direct_normal_irradiance
+        self.diffuse_horizontal_irradiance = diffuse_horizontal_irradiance
 
     @classmethod
-    def from_values(cls, location, direct_normal_radiation,
-                    diffuse_horizontal_radiation, timestep=1, is_leap_year=False):
-        """Create wea from a list of radiation values.
+    def from_values(cls, location, direct_normal_irradiance,
+                    diffuse_horizontal_irradiance, timestep=1, is_leap_year=False):
+        """Create wea from a list of irradiance values.
 
         This method converts input lists to DataCollection.
         """
         err_message = 'For timestep %d, %d number of data for %s is expected. ' \
             '%d is provided.'
-        if len(direct_normal_radiation) % cls.hour_count(is_leap_year) == 0:
+        if len(direct_normal_irradiance) % cls.hr_count(is_leap_year) == 0:
             # add extra information to err_message
             err_message = err_message + ' Did you forget to set the timestep to %d?' \
-                % (len(direct_normal_radiation) / cls.hour_count(is_leap_year))
+                % (len(direct_normal_irradiance) / cls.hr_count(is_leap_year))
 
-        assert len(direct_normal_radiation) / timestep == cls.hour_count(is_leap_year), \
-            err_message % (timestep, timestep * cls.hour_count(is_leap_year),
-                           'direct normal radiation', len(direct_normal_radiation))
+        assert len(direct_normal_irradiance) / timestep == cls.hr_count(is_leap_year), \
+            err_message % (timestep, timestep * cls.hr_count(is_leap_year),
+                           'direct normal irradiance', len(
+                               direct_normal_irradiance))
 
-        assert len(diffuse_horizontal_radiation) / timestep == \
-            cls.hour_count(is_leap_year), \
-            err_message % (timestep, timestep * cls.hour_count(is_leap_year),
-                           'diffuse_horizontal_radiation', len(direct_normal_radiation))
+        assert len(diffuse_horizontal_irradiance) / timestep == \
+            cls.hr_count(is_leap_year), \
+            err_message % (timestep, timestep * cls.hr_count(is_leap_year),
+                           'diffuse_horizontal_irradiance', len(
+                               direct_normal_irradiance))
 
         dnr, dhr = cls._get_empty_data_collections(location, timestep, is_leap_year)
         dts = cls._get_datetimes(timestep, is_leap_year)
-        for dir_norm, diff_horiz, dt in zip(direct_normal_radiation,
-                                            diffuse_horizontal_radiation, dts):
-            dnr.append(DataPoint(dir_norm, dt, 'SI', 'Direct Normal Radiation'))
-            dhr.append(DataPoint(diff_horiz, dt, 'SI', 'Diffuse Horizontal Radiation'))
+        for dir_norm, diff_horiz, dt in zip(direct_normal_irradiance,
+                                            diffuse_horizontal_irradiance, dts):
+            dnr.append(DataPoint(dir_norm, dt, 'SI', 'Direct Normal Irradiance'))
+            dhr.append(DataPoint(diff_horiz, dt, 'SI', 'Diffuse Horizontal Irradiance'))
         return cls(location, dnr, dhr, timestep, is_leap_year)
 
     @classmethod
@@ -95,15 +97,15 @@ class Wea(object):
         """ Create Wea from json file
             {
             "location": {} , // ladybug location schema
-            "direct_normal_radiation": [], // List of hourly direct normal
-                radiation data points
-            "diffuse_horizontal_radiation": [], // List of hourly diffuse
-                horizontal radiation data points
+            "direct_normal_irradiance": [], // List of hourly direct normal
+                irradiance data points
+            "diffuse_horizontal_irradiance": [], // List of hourly diffuse
+                horizontal irradiance data points
             "timestep": float //timestep between measurements, default is 1
             }
         """
-        required_keys = ('location', 'direct_normal_radiation',
-                         'diffuse_horizontal_radiation')
+        required_keys = ('location', 'direct_normal_irradiance',
+                         'diffuse_horizontal_irradiance')
         optional_keys = ('timestep', 'is_leap_year')
 
         for key in required_keys:
@@ -114,15 +116,15 @@ class Wea(object):
                 data[key] = None
 
         location = Location.from_json(data['location'])
-        direct_normal_radiation = \
-            DataCollection.from_json(data['direct_normal_radiation'])
-        diffuse_horizontal_radiation = \
-            DataCollection.from_json(data['diffuse_horizontal_radiation'])
+        direct_normal_irradiance = \
+            DataCollection.from_json(data['direct_normal_irradiance'])
+        diffuse_horizontal_irradiance = \
+            DataCollection.from_json(data['diffuse_horizontal_irradiance'])
         timestep = data['timestep']
         is_leap_year = data['is_leap_year']
 
-        return cls(location, direct_normal_radiation,
-                   diffuse_horizontal_radiation, timestep, is_leap_year)
+        return cls(location, direct_normal_irradiance,
+                   diffuse_horizontal_irradiance, timestep, is_leap_year)
 
     # TOD(mostapha): If decided that this is a good idea, also parse datetime from wea
     # file. It is currently auto-generated based on timestep to ensure it will be
@@ -154,20 +156,20 @@ class Wea(object):
             location.elevation = float(weaf.readline().split()[-1])
             weaf.readline()  # pass line for weather data units
 
-            # parse radiation values
-            direct_normal_radiation = []
-            diffuse_horizontal_radiation = []
+            # parse irradiance values
+            direct_normal_irradiance = []
+            diffuse_horizontal_irradiance = []
             for line in weaf:
                 dirn, difh = [int(v) for v in line.split()[-2:]]
-                direct_normal_radiation.append(dirn)
-                diffuse_horizontal_radiation.append(difh)
+                direct_normal_irradiance.append(dirn)
+                diffuse_horizontal_irradiance.append(difh)
 
-        return cls.from_values(location, direct_normal_radiation,
-                               diffuse_horizontal_radiation, timestep, is_leap_year)
+        return cls.from_values(location, direct_normal_irradiance,
+                               diffuse_horizontal_irradiance, timestep, is_leap_year)
 
     @classmethod
     def from_epw_file(cls, epwfile, timestep=1):
-        """Create a wea object using the solar radiation values in an epw file.
+        """Create a wea object using the solar irradiance values in an epw file.
 
         Args:
             epwfile: Full path to epw weather file.
@@ -183,6 +185,10 @@ class Wea(object):
         epw = EPW(epwfile)
         direct_normal = epw.direct_normal_radiation
         diffuse_horizontal = epw.diffuse_horizontal_radiation
+        direct_normal.header.set_data_type_and_unit(
+            'Direct Normal Irradiance', 'W/m2')
+        diffuse_horizontal.header.set_data_type_and_unit(
+            'Diffuse Horizontal Irradiance', 'W/m2')
         if timestep != 1:
             print ("Note: timesteps greater than 1 on epw-generated Wea's \n" +
                    "are suitable for thermal models but are not recommended \n" +
@@ -197,16 +203,16 @@ class Wea(object):
             sp = Sunpath.from_location(epw.location)
             # add correct values to the emply data collection
             for e_beam, e_diff in zip(direct_norm_values, diffuse_horiz_values):
-                # set radiation values to 0 when the sun is not up
+                # set irradiance values to 0 when the sun is not up
                 sun = sp.calculate_sun_from_date_time(e_beam.datetime)
                 if sun.altitude > 0:
                     direct_normal.append(e_beam)
                     diffuse_horizontal.append(e_diff)
                 else:
                     direct_normal.append(DataPoint(
-                        0, e_beam.datetime, 'SI', 'Direct Normal Radiation'))
+                        0, e_beam.datetime, 'SI', 'Direct Normal Irradiance'))
                     diffuse_horizontal.append(DataPoint(
-                        0, e_diff.datetime, 'SI', 'Diffuse Horizontal Radiation'))
+                        0, e_diff.datetime, 'SI', 'Diffuse Horizontal Irradiance'))
         else:
             # add half an hour to datetime to put sun in the middle of the hour
             for dnr in direct_normal:
@@ -294,9 +300,9 @@ class Wea(object):
                 alt_list, monthly_tau_beam[i_mon], monthly_tau_diffuse[i_mon])
             for e_beam, e_diff in zip(dir_norm_rad, dif_horiz_rad):
                 direct_norm_rad.append(DataPoint(
-                    e_beam, dates[i_dt], 'SI', 'Direct Normal Radiation'))
+                    e_beam, dates[i_dt], 'SI', 'Direct Normal Irradiance'))
                 diffuse_horiz_rad.append(DataPoint(
-                    e_diff, dates[i_dt], 'SI', 'Diffuse Horizontal Radiation'))
+                    e_diff, dates[i_dt], 'SI', 'Diffuse Horizontal Irradiance'))
                 i_dt += 1
 
         return cls(location, direct_norm_rad, diffuse_horiz_rad, timestep, is_leap_year)
@@ -309,7 +315,7 @@ class Wea(object):
         The original ASHRAE Clear Sky is intended to determine peak solar load
         and sizing parmeters for HVAC systems.  It is not the sky model
         currently recommended by ASHRAE since it usually overestimates the
-        amount of solar radiation in comparison to the newer ASHRAE Revised
+        amount of solar irradiance in comparison to the newer ASHRAE Revised
         Clear Sky ("Tau Model"). However, the original model here is still
         useful for cases where monthly optical depth values are not known. For
         more information on the ASHRAE Clear Sky model, see the EnergyPlus
@@ -343,16 +349,16 @@ class Wea(object):
             sun = sp.calculate_sun_from_date_time(t_date)
             altitudes[sun.datetime.month - 1].append(sun.altitude)
 
-        # compute hourly direct normal and diffuse horizontal radiation
+        # compute hourly direct normal and diffuse horizontal irradiance
         i_dt = 0
         for i_mon, alt_list in enumerate(altitudes):
             dir_norm_rad, dif_horiz_rad = ashrae_clear_sky(
                 alt_list, i_mon + 1, sky_clearness)
             for e_beam, e_diff in zip(dir_norm_rad, dif_horiz_rad):
                 direct_norm_rad.append(DataPoint(
-                    e_beam, dates[i_dt], 'SI', 'Direct Normal Radiation'))
+                    e_beam, dates[i_dt], 'SI', 'Direct Normal Irradiance'))
                 diffuse_horiz_rad.append(DataPoint(
-                    e_diff, dates[i_dt], 'SI', 'Diffuse Horizontal Radiation'))
+                    e_diff, dates[i_dt], 'SI', 'Diffuse Horizontal Irradiance'))
                 i_dt += 1
 
         return cls(location, direct_norm_rad, diffuse_horiz_rad, timestep, is_leap_year)
@@ -364,10 +370,10 @@ class Wea(object):
         """Create a wea object from climate data using the Zhang-Huang model.
 
         The Zhang-Huang solar model was developed to estimate solar
-        radiation for weather stations that lack such values, which are
+        irradiance for weather stations that lack such values, which are
         typically colleted with a pyranometer. Using total cloud cover,
         dry-bulb temperature, relative humidity, and wind speed as
-        inputs the Zhang-Huang estimates global horizontal radiation
+        inputs the Zhang-Huang estimates global horizontal irradiance
         by means of a regression model across these variables.
         For more information on the Zhang-Huang model, see the
         EnergyPlus Engineering Reference:
@@ -393,7 +399,7 @@ class Wea(object):
         assert len(cloud_cover) == len(relative_humidity) == \
             len(dry_bulb_temperature) == len(wind_speed), \
             'lengths of input climate data must match.'
-        assert len(cloud_cover) / timestep == cls.hour_count(is_leap_year), \
+        assert len(cloud_cover) / timestep == cls.hr_count(is_leap_year), \
             'input climate data must be annual.'
         assert isinstance(timestep, int), 'timestep must be an' \
             ' integer. Got {}'.format(type(timestep))
@@ -402,7 +408,7 @@ class Wea(object):
         sp = Sunpath.from_location(location)
         sp.is_leap_year = is_leap_year
 
-        # calculate zhang-huang radiation
+        # calculate zhang-huang irradiance
         direct_norm_rad, diffuse_horiz_rad = \
             cls._get_empty_data_collections(location, timestep, is_leap_year)
 
@@ -419,9 +425,9 @@ class Wea(object):
                 wind_speed[count])
 
             direct_norm_rad.append(DataPoint(
-                dir_ir, t_date, 'SI', 'Direct Normal Radiation'))
+                dir_ir, t_date, 'SI', 'Direct Normal Irradiance'))
             diffuse_horiz_rad.append(DataPoint(
-                diff_ir, t_date, 'SI', 'Diffuse Horizontal Radiation'))
+                diff_ir, t_date, 'SI', 'Diffuse Horizontal Irradiance'))
 
         return cls(location, direct_norm_rad, diffuse_horiz_rad, timestep, is_leap_year)
 
@@ -433,12 +439,12 @@ class Wea(object):
     @property
     def hoys(self):
         """Hours of the year in wea file."""
-        return tuple(data.datetime.hoy for data in self.direct_normal_radiation)
+        return tuple(data.datetime.hoy for data in self.direct_normal_irradiance)
 
     @property
     def datetimes(self):
         """Datetimes in wea file."""
-        return tuple(data.datetime for data in self.direct_normal_radiation)
+        return tuple(data.datetime for data in self.direct_normal_irradiance)
 
     @property
     def timestep(self):
@@ -446,73 +452,73 @@ class Wea(object):
         return self._timestep
 
     @property
-    def direct_normal_radiation(self):
-        """Get or set the direct normal radiation."""
-        return self._direct_normal_radiation
+    def direct_normal_irradiance(self):
+        """Get or set the direct normal irradiance."""
+        return self._direct_normal_irradiance
 
-    @direct_normal_radiation.setter
-    def direct_normal_radiation(self, data):
-        assert isinstance(data, DataCollection), 'direct_normal_radiation data' \
+    @direct_normal_irradiance.setter
+    def direct_normal_irradiance(self, data):
+        assert isinstance(data, DataCollection), 'direct_normal_irradiance data' \
             ' must be a data collection. Got {}'.format(type(data))
-        assert len(data) / self.timestep == self.hour_count(self.is_leap_year), \
-            'direct_normal_radiation data must be annual.'
-        self._direct_normal_radiation = data
+        assert len(data) / self.timestep == self.hr_count(self.is_leap_year), \
+            'direct_normal_irradiance data must be annual.'
+        self._direct_normal_irradiance = data
 
     @property
-    def diffuse_horizontal_radiation(self):
-        """Get or set the diffuse horizontal radiation."""
-        return self._diffuse_horizontal_radiation
+    def diffuse_horizontal_irradiance(self):
+        """Get or set the diffuse horizontal irradiance."""
+        return self._diffuse_horizontal_irradiance
 
-    @diffuse_horizontal_radiation.setter
-    def diffuse_horizontal_radiation(self, data):
-        assert isinstance(data, DataCollection), 'diffuse_horizontal_radiation data' \
+    @diffuse_horizontal_irradiance.setter
+    def diffuse_horizontal_irradiance(self, data):
+        assert isinstance(data, DataCollection), 'diffuse_horizontal_irradiance data' \
             ' must be a data collection. Got {}'.format(type(data))
-        assert len(data) / self.timestep == self.hour_count(self.is_leap_year), \
-            'diffuse_horizontal_radiation data must be annual.'
-        self._diffuse_horizontal_radiation = data
+        assert len(data) / self.timestep == self.hr_count(self.is_leap_year), \
+            'diffuse_horizontal_irradiance data must be annual.'
+        self._diffuse_horizontal_irradiance = data
 
     @property
-    def global_horizontal_radiation(self):
-        """Returns the global horizontal radiation at each timestep."""
+    def global_horizontal_irradiance(self):
+        """Returns the global horizontal irradiance at each timestep."""
         analysis_period = AnalysisPeriod(timestep=self.timestep,
                                          is_leap_year=self.is_leap_year)
-        header_ghr = Header(location=self.location,
-                            analysis_period=analysis_period,
-                            data_type='Global Horizontal Radiation',
-                            unit='W/m2')
+        header_ghr = Header(analysis_period=analysis_period,
+                            data_type='Global Horizontal Irradiance',
+                            unit='W/m2',
+                            location=self.location)
         global_horizontal_rad = DataCollection(header=header_ghr)
         is_leap_year = self.is_leap_year
         sp = Sunpath.from_location(self.location)
         sp.is_leap_year = is_leap_year
-        for dnr, dhr in zip(self.direct_normal_radiation,
-                            self.diffuse_horizontal_radiation):
+        for dnr, dhr in zip(self.direct_normal_irradiance,
+                            self.diffuse_horizontal_irradiance):
             sun = sp.calculate_sun_from_date_time(dnr.datetime)
             glob_h = dhr + dnr * math.sin(math.radians(sun.altitude))
             global_horizontal_rad.append(
-                DataPoint(glob_h, dnr.datetime, 'SI', 'Global Horizontal Radiation'))
+                DataPoint(glob_h, dnr.datetime, 'SI', 'Global Horizontal Irradiance'))
         return global_horizontal_rad
 
     @property
-    def direct_horizontal_radiation(self):
-        """Returns the direct radiation on a horizontal surface at each timestep.
+    def direct_horizontal_irradiance(self):
+        """Returns the direct irradiance on a horizontal surface at each timestep.
 
-        Note that this is different from the direct_normal_radiation needed
+        Note that this is different from the direct_normal_irradiance needed
         to construct a Wea, which is NORMAL and not HORIZONTAL."""
         analysis_period = AnalysisPeriod(timestep=self.timestep,
                                          is_leap_year=self.is_leap_year)
-        header_dhr = Header(location=self.location,
-                            analysis_period=analysis_period,
-                            data_type='Direct Horizontal Radiation',
-                            unit='W/m2')
+        header_dhr = Header(analysis_period=analysis_period,
+                            data_type='Direct Horizontal Irradiance',
+                            unit='W/m2',
+                            location=self.location)
         direct_horizontal_rad = DataCollection(header=header_dhr)
         is_leap_year = self.is_leap_year
         sp = Sunpath.from_location(self.location)
         sp.is_leap_year = is_leap_year
-        for dnr in self.direct_normal_radiation:
+        for dnr in self.direct_normal_irradiance:
             sun = sp.calculate_sun_from_date_time(dnr.datetime)
             dir_h = dnr * math.sin(math.radians(sun.altitude))
             direct_horizontal_rad.append(
-                DataPoint(dir_h, dnr.datetime, 'SI', 'Direct Horizontal Radiation'))
+                DataPoint(dir_h, dnr.datetime, 'SI', 'Direct Horizontal Irradiance'))
         return direct_horizontal_rad
 
     @property
@@ -521,7 +527,7 @@ class Wea(object):
         return self._is_leap_year
 
     @staticmethod
-    def hour_count(is_leap_year):
+    def hr_count(is_leap_year):
         """Number of hours in this Wea file.
 
         Keep in mind that wea file is an annual file but this value will be different
@@ -536,73 +542,73 @@ class Wea(object):
         This method should only be used for classmethods. For datetimes use datetiems or
         hoys methods.
         """
-        hour_count = 8760 + 24 if is_leap_year else 8760
+        hr_count = 8760 + 24 if is_leap_year else 8760
         adjust_time = 30 if timestep == 1 else 0
         return tuple(
             DateTime.from_moy(60.0 * count / timestep + adjust_time, is_leap_year)
-            for count in xrange(hour_count * timestep)
+            for count in xrange(hr_count * timestep)
         )
 
     @staticmethod
     def _get_empty_data_collections(location, timestep, is_leap_year):
         """Return two empty data collection.
 
-        Direct Normal Radiation, Diffuse Horizontal Radiation
+        Direct Normal Irradiance, Diffuse Horizontal Irradiance
         """
         analysis_period = AnalysisPeriod(timestep=timestep, is_leap_year=is_leap_year)
-        header_dnr = Header(location=location,
-                            analysis_period=analysis_period,
-                            data_type='Direct Normal Radiation',
-                            unit='W/m2')
+        header_dnr = Header(analysis_period=analysis_period,
+                            data_type='Direct Normal Irradiance',
+                            unit='W/m2',
+                            location=location)
         direct_norm_rad = DataCollection(header=header_dnr)
-        header_dhr = Header(location=location,
-                            analysis_period=analysis_period,
-                            data_type='Diffuse Horizontal Radiation',
-                            unit='W/m2')
+        header_dhr = Header(analysis_period=analysis_period,
+                            data_type='Diffuse Horizontal Irradiance',
+                            unit='W/m2',
+                            location=location)
         diffuse_horiz_rad = DataCollection(header=header_dhr)
 
         return direct_norm_rad, diffuse_horiz_rad
 
-    def get_radiation_values(self, month, day, hour):
-        """Get direct and diffuse radiation values for a point in time."""
+    def get_irradiance_values(self, month, day, hour):
+        """Get direct and diffuse irradiance values for a point in time."""
         dt = DateTime(month, day, hour, leap_year=self.is_leap_year)
         count = int(dt.hoy * self.timestep)
-        return self.direct_normal_radiation[count], \
-            self.diffuse_horizontal_radiation[count]
+        return self.direct_normal_irradiance[count], \
+            self.diffuse_horizontal_irradiance[count]
 
-    def get_radiation_values_for_hoy(self, hoy):
-        """Get direct and diffuse radiation values for an hoy."""
+    def get_irradiance_values_for_hoy(self, hoy):
+        """Get direct and diffuse irradiance values for an hoy."""
         count = int(hoy * self.timestep)
-        return self.direct_normal_radiation[count], \
-            self.diffuse_horizontal_radiation[count]
+        return self.direct_normal_irradiance[count], \
+            self.diffuse_horizontal_irradiance[count]
 
-    def directional_radiation(self, altitude=90, azimuth=180,
-                              ground_reflectance=0.2, isotrophic=True):
-        """Returns the radiation components facing a given altitude and azimuth.
+    def directional_irradiance(self, altitude=90, azimuth=180,
+                               ground_reflectance=0.2, isotrophic=True):
+        """Returns the irradiance components facing a given altitude and azimuth.
 
         This method computes unobstructed solar flux facing a given
         altitude and azimuth. The default is set to return the golbal horizontal
-        radiation, assuming an altitude facing straight up (90 degrees).
+        irradiance, assuming an altitude facing straight up (90 degrees).
 
         Args:
             altitude: A number between -90 and 90 that represents the
-                altitude at which radiation is being evaluated in degrees.
+                altitude at which irradiance is being evaluated in degrees.
             azimuth: A number between 0 and 360 that represents the
-                azimuth at wich radiation is being evaluated in degrees.
+                azimuth at wich irradiance is being evaluated in degrees.
             ground_reflectance: A number between 0 and 1 that represents the
                 reflectance of the ground. Default is set to 0.2.
             isotrophic: A boolean value that sets whether an istotrophic sky is
                 used (as opposed to an anisotrophic sky). An isotrophic sky
-                assummes an even distribution of diffuse radiation across the
-                sky while an anisotrophic sky places more diffuse radiation
+                assummes an even distribution of diffuse irradiance across the
+                sky while an anisotrophic sky places more diffuse irradiance
                 near the solar disc. Default is set to True for isotrophic
 
         Returns:
-            total_radiation: A list of total solar radiation at each timestep.
-            direct_radiation: A list of direct solar radiation at each timestep.
-            diffuse_radiation: A list of diffuse sky solar radiation
+            total_irradiance: A list of total solar irradiance at each timestep.
+            direct_irradiance: A list of direct solar irradiance at each timestep.
+            diffuse_irradiance: A list of diffuse sky solar irradiance
                 at each timestep.
-            reflected_radiation: A list of ground reflected solar radiation
+            reflected_irradiance: A list of ground reflected solar irradiance
                 at each timestep.
         """
         # function to convert polar coordinates to xyz.
@@ -617,26 +623,26 @@ class Wea(object):
         normal = pol2cart(math.radians(azimuth), math.radians(altitude))
 
         # create sunpath and get altitude at every timestep of the year
-        direct_radiation = []
-        diffuse_radiation = []
-        reflected_radiation = []
-        total_radiation = []
+        direct_irradiance = []
+        diffuse_irradiance = []
+        reflected_irradiance = []
+        total_irradiance = []
         sp = Sunpath.from_location(self.location)
         sp.is_leap_year = self.is_leap_year
-        for dnr, dhr in zip(self.direct_normal_radiation,
-                            self.diffuse_horizontal_radiation):
+        for dnr, dhr in zip(self.direct_normal_irradiance,
+                            self.diffuse_horizontal_irradiance):
             dt = dnr.datetime
             sun = sp.calculate_sun_from_date_time(dt)
             sun_vec = pol2cart(math.radians(sun.azimuth),
                                math.radians(sun.altitude))
             vec_angle = sun_vec.angle(normal)
 
-            # direct radiation on surface
+            # direct irradiance on surface
             srf_dir = 0
             if sun.altitude > 0 and vec_angle < math.pi / 2:
                 srf_dir = dnr * math.cos(vec_angle)
 
-            # diffuse radiation on surface
+            # diffuse irradiance on surface
             if isotrophic is True:
                 srf_dif = dhr * ((math.sin(math.radians(altitude)) / 2) + 0.5)
             else:
@@ -646,23 +652,23 @@ class Wea(object):
                     math.sin(math.radians(abs(90 - altitude)))) +
                     math.cos(math.radians(abs(90 - altitude))))
 
-            # reflected radiation on surface.
+            # reflected irradiance on surface.
             e_glob = dhr + dnr * math.cos(math.radians(90 - sun.altitude))
             srf_ref = e_glob * ground_reflectance * (0.5 - (math.sin(
                 math.radians(altitude)) / 2))
 
             # add it all together
-            direct_radiation.append(
-                DataPoint(srf_dir, dt, 'SI', 'Radiation'))
-            diffuse_radiation.append(
-                DataPoint(srf_dif, dt, 'SI', 'Radiation'))
-            reflected_radiation.append(
-                DataPoint(srf_ref, dt, 'SI', 'Radiation'))
-            total_radiation.append(
-                DataPoint(srf_dir + srf_dif + srf_ref, dt, 'SI', 'Radiation'))
+            direct_irradiance.append(
+                DataPoint(srf_dir, dt, 'SI', 'Irradiance'))
+            diffuse_irradiance.append(
+                DataPoint(srf_dif, dt, 'SI', 'Irradiance'))
+            reflected_irradiance.append(
+                DataPoint(srf_ref, dt, 'SI', 'Irradiance'))
+            total_irradiance.append(
+                DataPoint(srf_dir + srf_dif + srf_ref, dt, 'SI', 'Irradiance'))
 
-        return total_radiation, direct_radiation, \
-            diffuse_radiation, reflected_radiation
+        return total_irradiance, direct_irradiance, \
+            diffuse_irradiance, reflected_irradiance
 
     @property
     def header(self):
@@ -678,19 +684,19 @@ class Wea(object):
         """Write Wea to json file
             {
             "location": {} , // ladybug location schema
-            "direct_normal_radiation": (), // Tuple of hourly direct normal
-                radiation
-            "diffuse_horizontal_radiation": (), // Tuple of hourly diffuse
-                horizontal radiation
+            "direct_normal_irradiance": (), // Tuple of hourly direct normal
+                irradiance
+            "diffuse_horizontal_irradiance": (), // Tuple of hourly diffuse
+                horizontal irradiance
             "timestep": float //timestep between measurements, default is 1
             }
         """
         return {
             'location': self.location.to_json(),
-            'direct_normal_radiation':
-                self.direct_normal_radiation.to_json(),
-            'diffuse_horizontal_radiation':
-                self.diffuse_horizontal_radiation.to_json(),
+            'direct_normal_irradiance':
+                self.direct_normal_irradiance.to_json(),
+            'diffuse_horizontal_irradiance':
+                self.diffuse_horizontal_irradiance.to_json(),
             'timestep': self.timestep,
             'is_leap_year': self.is_leap_year
         }
@@ -698,7 +704,7 @@ class Wea(object):
     def write(self, file_path, hoys=None, write_hours=False):
         """Write the wea file.
 
-        WEA carries radiation values from epw and is what gendaymtx uses to
+        WEA carries irradiance values from epw and is what gendaymtx uses to
         generate the sky.
         """
         if not file_path.lower().endswith('.wea'):
@@ -715,8 +721,8 @@ class Wea(object):
         if full_wea:
             # there is no input user for hoys, write it for all the hours
             # write values
-            for dir_rad, dif_rad in zip(self.direct_normal_radiation,
-                                        self.diffuse_horizontal_radiation):
+            for dir_rad, dif_rad in zip(self.direct_normal_irradiance,
+                                        self.diffuse_horizontal_irradiance):
                 dt = dir_rad.datetime
                 line = "%d %d %.3f %d %d\n" \
                     % (dt.month, dt.day, dt.float_hour, dir_rad, dif_rad)
@@ -725,7 +731,7 @@ class Wea(object):
             # output wea based on user request
             for hoy in hoys:
                 try:
-                    dir_rad, dif_rad = self.get_radiation_values_for_hoy(hoy)
+                    dir_rad, dif_rad = self.get_irradiance_values_for_hoy(hoy)
                 except IndexError:
                     print('Warn: Wea data for {} is not available!'.format(dt))
                     continue

--- a/tests/datacollection_test.py
+++ b/tests/datacollection_test.py
@@ -7,6 +7,7 @@ from ladybug.dt import DateTime
 from ladybug.datacollection import DataCollection
 from ladybug.header import Header
 from ladybug.analysisperiod import AnalysisPeriod
+from ladybug.datatypenew import Temperature
 
 
 class DataCollectionTestCase(unittest.TestCase):
@@ -44,6 +45,26 @@ class DataCollectionTestCase(unittest.TestCase):
         assert dc1.datetimes == (dt1, dt2)
         assert dc1.data == [v1, v2]
         assert dc1.average_data() == average
+
+    def test_to_unit(self):
+        """Test the conversion of DataCollection units."""
+        # Setup Datetimes
+        vals = [20]
+        dc1 = DataCollection.from_list(vals, Temperature(), 'C')
+        dc2 = dc1.to_unit('K')
+        assert dc1.values[0] == 20
+        assert dc2.values[0] == 293.15
+
+    def test_to_ip_si(self):
+        """Test the conversion of DataCollection to IP and SI units."""
+        # Setup Datetimes
+        vals = [20]
+        dc1 = DataCollection.from_list(vals, Temperature(), 'C')
+        dc2 = dc1.to_ip()
+        dc3 = dc2.to_si()
+        assert dc1.values[0] == 20
+        assert dc2.values[0] == 68
+        assert dc3.values[0] == dc1.values[0]
 
     def test_interpolation(self):
         # To test an annual data collection, we will just use a range of values

--- a/tests/datacollection_test.py
+++ b/tests/datacollection_test.py
@@ -49,7 +49,7 @@ class DataCollectionTestCase(unittest.TestCase):
         # To test an annual data collection, we will just use a range of values
         test_data = range(8760)
         ap = AnalysisPeriod()
-        test_header = Header(None, None, None, ap, False)
+        test_header = Header('Test Type', None, None, ap)
         dc2 = DataCollection.from_data_and_analysis_period(test_data, ap, test_header)
 
         # check the interpolate data functions

--- a/tests/datacollection_test.py
+++ b/tests/datacollection_test.py
@@ -49,7 +49,8 @@ class DataCollectionTestCase(unittest.TestCase):
         # To test an annual data collection, we will just use a range of values
         test_data = range(8760)
         ap = AnalysisPeriod()
-        test_header = Header('Test Type', None, None, ap)
+        test_header = Header(
+            data_type='Test Type', unit=None, analysis_period=ap, location=None)
         dc2 = DataCollection.from_data_and_analysis_period(test_data, ap, test_header)
 
         # check the interpolate data functions

--- a/tests/datacollection_test.py
+++ b/tests/datacollection_test.py
@@ -8,6 +8,7 @@ from ladybug.datacollection import DataCollection
 from ladybug.header import Header
 from ladybug.analysisperiod import AnalysisPeriod
 from ladybug.datatypenew import Temperature
+from ladybug.datatypenew import RelativeHumidity
 
 
 class DataCollectionTestCase(unittest.TestCase):
@@ -65,6 +66,43 @@ class DataCollectionTestCase(unittest.TestCase):
         assert dc1.values[0] == 20
         assert dc2.values[0] == 68
         assert dc3.values[0] == dc1.values[0]
+
+    def test_is_in_range(self):
+        """Test the function to check whether values are in a specific range."""
+        val1 = [50]
+        dc1 = DataCollection.from_list(val1, Temperature(), 'C')
+        assert dc1.is_in_range(0, 100) is True
+        assert dc1.is_in_range(0, 30) is False
+
+    def test_is_in_range_data_type(self):
+        """Test the function to check whether values are in range for the data_type."""
+        val1 = [20]
+        val2 = [-300]
+        val3 = [270]
+        val4 = [-10]
+        dc1 = DataCollection.from_list(val1, Temperature(), 'C')
+        dc2 = DataCollection.from_list(val2, Temperature(), 'C')
+        dc3 = DataCollection.from_list(val3, Temperature(), 'K')
+        dc4 = DataCollection.from_list(val4, Temperature(), 'K')
+        assert dc1.is_in_range_data_type() is True
+        assert dc2.is_in_range_data_type() is False
+        assert dc3.is_in_range_data_type() is True
+        assert dc4.is_in_range_data_type() is False
+
+    def test_is_in_range_epw(self):
+        """Test the function to check whether values are in range for an EPW."""
+        val1 = [50]
+        val2 = [150]
+        val3 = [0.5]
+        val4 = [1.5]
+        dc1 = DataCollection.from_list(val1, RelativeHumidity(), '%')
+        dc2 = DataCollection.from_list(val2, RelativeHumidity(), '%')
+        dc3 = DataCollection.from_list(val3, RelativeHumidity(), 'fraction')
+        dc4 = DataCollection.from_list(val4, RelativeHumidity(), 'fraction')
+        assert dc1.is_in_range_epw() is True
+        assert dc2.is_in_range_epw() is False
+        assert dc3.is_in_range_epw() is True
+        assert dc4.is_in_range_epw() is False
 
     def test_interpolation(self):
         # To test an annual data collection, we will just use a range of values

--- a/tests/wea_test.py
+++ b/tests/wea_test.py
@@ -26,10 +26,10 @@ class WeaTestCase(unittest.TestCase):
             Wea.from_file(wea_file)  # wrong timestep
 
         wea = Wea.from_file(wea_file, 6)
-        assert wea.direct_normal_radiation[45] == 88
-        assert wea.diffuse_horizontal_radiation[45] == 1
-        assert wea.direct_normal_radiation[46] == 313
-        assert wea.diffuse_horizontal_radiation[46] == 3
+        assert wea.direct_normal_irradiance[45] == 88
+        assert wea.diffuse_horizontal_irradiance[45] == 1
+        assert wea.direct_normal_irradiance[46] == 313
+        assert wea.diffuse_horizontal_irradiance[46] == 3
 
     def test_from_epw(self):
         """Test import from epw"""
@@ -38,19 +38,19 @@ class WeaTestCase(unittest.TestCase):
 
         assert wea_from_epw.location.city == 'Chicago Ohare Intl Ap'
         assert wea_from_epw.timestep == 1
-        assert wea_from_epw.direct_normal_radiation[7] == 22
-        assert wea_from_epw.direct_normal_radiation[7].datetime.hour == 7
-        assert wea_from_epw.direct_normal_radiation[7].datetime.minute == 30
-        assert wea_from_epw.direct_normal_radiation[8] == 397
-        assert wea_from_epw.direct_normal_radiation[8].datetime.hour == 8
-        assert wea_from_epw.direct_normal_radiation[8].datetime.minute == 30
-        # diffuse horizontal radiation
-        assert wea_from_epw.diffuse_horizontal_radiation[7] == 10
-        assert wea_from_epw.diffuse_horizontal_radiation[7].datetime.hour == 7
-        assert wea_from_epw.diffuse_horizontal_radiation[7].datetime.minute == 30
-        assert wea_from_epw.diffuse_horizontal_radiation[8] == 47
-        assert wea_from_epw.diffuse_horizontal_radiation[8].datetime.hour == 8
-        assert wea_from_epw.diffuse_horizontal_radiation[8].datetime.minute == 30
+        assert wea_from_epw.direct_normal_irradiance[7] == 22
+        assert wea_from_epw.direct_normal_irradiance[7].datetime.hour == 7
+        assert wea_from_epw.direct_normal_irradiance[7].datetime.minute == 30
+        assert wea_from_epw.direct_normal_irradiance[8] == 397
+        assert wea_from_epw.direct_normal_irradiance[8].datetime.hour == 8
+        assert wea_from_epw.direct_normal_irradiance[8].datetime.minute == 30
+        # diffuse horizontal irradiance
+        assert wea_from_epw.diffuse_horizontal_irradiance[7] == 10
+        assert wea_from_epw.diffuse_horizontal_irradiance[7].datetime.hour == 7
+        assert wea_from_epw.diffuse_horizontal_irradiance[7].datetime.minute == 30
+        assert wea_from_epw.diffuse_horizontal_irradiance[8] == 47
+        assert wea_from_epw.diffuse_horizontal_irradiance[8].datetime.hour == 8
+        assert wea_from_epw.diffuse_horizontal_irradiance[8].datetime.minute == 30
 
     def test_from_stat(self):
         """Test import from stat"""
@@ -59,13 +59,13 @@ class WeaTestCase(unittest.TestCase):
 
         assert wea_from_stat.location.city == 'Chicago Ohare Intl Ap'
         assert wea_from_stat.timestep == 1
-        assert wea_from_stat.diffuse_horizontal_radiation[0].value == \
+        assert wea_from_stat.diffuse_horizontal_irradiance[0].value == \
             pytest.approx(0, rel=1e-3)
-        assert wea_from_stat.direct_normal_radiation[0].value == \
+        assert wea_from_stat.direct_normal_irradiance[0].value == \
             pytest.approx(0, rel=1e-3)
-        assert wea_from_stat.diffuse_horizontal_radiation[12].value == \
+        assert wea_from_stat.diffuse_horizontal_irradiance[12].value == \
             pytest.approx(87.44171, rel=1e-3)
-        assert wea_from_stat.direct_normal_radiation[12].value == \
+        assert wea_from_stat.direct_normal_irradiance[12].value == \
             pytest.approx(810.693919, rel=1e-3)
 
     def test_from_stat_missing_optical(self):
@@ -83,13 +83,13 @@ class WeaTestCase(unittest.TestCase):
 
         assert wea_from_clear_sky.location.city == 'Chicago Ohare Intl Ap'
         assert wea_from_clear_sky.timestep == 1
-        assert wea_from_clear_sky.diffuse_horizontal_radiation[0].value == \
+        assert wea_from_clear_sky.diffuse_horizontal_irradiance[0].value == \
             pytest.approx(0, rel=1e-3)
-        assert wea_from_clear_sky.direct_normal_radiation[0].value == \
+        assert wea_from_clear_sky.direct_normal_irradiance[0].value == \
             pytest.approx(0, rel=1e-3)
-        assert wea_from_clear_sky.diffuse_horizontal_radiation[12].value == \
+        assert wea_from_clear_sky.diffuse_horizontal_irradiance[12].value == \
             pytest.approx(60.72258, rel=1e-3)
-        assert wea_from_clear_sky.direct_normal_radiation[12].value == \
+        assert wea_from_clear_sky.direct_normal_irradiance[12].value == \
             pytest.approx(857.00439, rel=1e-3)
 
     def test_from_zhang_huang(self):
@@ -105,9 +105,9 @@ class WeaTestCase(unittest.TestCase):
 
         assert wea_from_zh.location.city == 'Chicago Ohare Intl Ap'
         assert wea_from_zh.timestep == 1
-        assert wea_from_zh.global_horizontal_radiation[0].value == \
+        assert wea_from_zh.global_horizontal_irradiance[0].value == \
             pytest.approx(0, rel=1e-3)
-        assert wea_from_zh.global_horizontal_radiation[12].value == \
+        assert wea_from_zh.global_horizontal_irradiance[12].value == \
             pytest.approx(281.97887, rel=1e-3)
         # TODO: Add checks for direct normal and diffuse once perez split is finished
 
@@ -126,10 +126,10 @@ class WeaTestCase(unittest.TestCase):
 
         wea_json = wea_from_epw.to_json()
         wea_from_json = Wea.from_json(wea_json)
-        assert wea_from_json.direct_normal_radiation.values == \
-            wea_from_epw.direct_normal_radiation.values
-        assert wea_from_json.diffuse_horizontal_radiation.values == \
-            wea_from_epw.diffuse_horizontal_radiation.values
+        assert wea_from_json.direct_normal_irradiance.values == \
+            wea_from_epw.direct_normal_irradiance.values
+        assert wea_from_json.diffuse_horizontal_irradiance.values == \
+            wea_from_epw.diffuse_horizontal_irradiance.values
 
     def test_import_stat(self):
         """Test to compare import from stat with its json version."""
@@ -138,10 +138,10 @@ class WeaTestCase(unittest.TestCase):
 
         wea_json = wea_from_stat.to_json()
         wea_from_json = Wea.from_json(wea_json)
-        assert wea_from_json.direct_normal_radiation.values == \
-            wea_from_stat.direct_normal_radiation.values
-        assert wea_from_json.diffuse_horizontal_radiation.values == \
-            wea_from_stat.diffuse_horizontal_radiation.values
+        assert wea_from_json.direct_normal_irradiance.values == \
+            wea_from_stat.direct_normal_irradiance.values
+        assert wea_from_json.diffuse_horizontal_irradiance.values == \
+            wea_from_stat.diffuse_horizontal_irradiance.values
 
     def test_write_wea(self):
         """Test the write Wea file capability."""
@@ -163,41 +163,41 @@ class WeaTestCase(unittest.TestCase):
             lines = wea_f.readlines()
             assert float(lines[6].split(' ')[-2]) == \
                 pytest.approx(
-                    wea_from_stat.direct_normal_radiation[0].value, rel=1e-1)
+                    wea_from_stat.direct_normal_irradiance[0].value, rel=1e-1)
             assert int(lines[6].split(' ')[-1]) == \
-                wea_from_stat.diffuse_horizontal_radiation[0].value
+                wea_from_stat.diffuse_horizontal_irradiance[0].value
             assert float(lines[17].split(' ')[-2]) == \
                 pytest.approx(
-                    wea_from_stat.direct_normal_radiation[11].value, rel=1e-1)
+                    wea_from_stat.direct_normal_irradiance[11].value, rel=1e-1)
             assert float(lines[17].split(' ')[-1]) == \
                 pytest.approx(
-                    wea_from_stat.diffuse_horizontal_radiation[11].value, rel=1e-1)
+                    wea_from_stat.diffuse_horizontal_irradiance[11].value, rel=1e-1)
 
         os.remove(wea_path)
         os.remove(hrs_path)
 
     def test_global_and_direct_horizontal(self):
-        """Test the global horizontal radiation on method."""
+        """Test the global horizontal irradiance on method."""
         stat_path = './tests/stat/chicago.stat'
         wea_from_stat = Wea.from_stat_file(stat_path)
 
-        diffuse_horiz_rad = wea_from_stat.diffuse_horizontal_radiation
-        direct_horiz_rad = wea_from_stat.direct_horizontal_radiation
-        glob_horiz_rad = wea_from_stat.global_horizontal_radiation
+        diffuse_horiz_rad = wea_from_stat.diffuse_horizontal_irradiance
+        direct_horiz_rad = wea_from_stat.direct_horizontal_irradiance
+        glob_horiz_rad = wea_from_stat.global_horizontal_irradiance
 
         assert [x.value for x in glob_horiz_rad] == pytest.approx(
             [x + y for x, y in zip(diffuse_horiz_rad, direct_horiz_rad)], rel=1e-3)
 
-    def test_directional_radiation(self):
-        """Test the directinal radiation method."""
+    def test_directional_irradiance(self):
+        """Test the directinal irradiance method."""
         stat_path = './tests/stat/chicago.stat'
         wea_from_stat = Wea.from_stat_file(stat_path)
 
         srf_total, srf_direct, srf_diffuse, srf_reflect = \
-            wea_from_stat.directional_radiation(90)
-        diffuse_horiz_rad = wea_from_stat.diffuse_horizontal_radiation
-        direct_horiz_rad = wea_from_stat.direct_horizontal_radiation
-        glob_horiz_rad = wea_from_stat.global_horizontal_radiation
+            wea_from_stat.directional_irradiance(90)
+        diffuse_horiz_rad = wea_from_stat.diffuse_horizontal_irradiance
+        direct_horiz_rad = wea_from_stat.direct_horizontal_irradiance
+        glob_horiz_rad = wea_from_stat.global_horizontal_irradiance
 
         assert [x.value for x in srf_total] == pytest.approx(
             [x.value for x in glob_horiz_rad], rel=1e-3)
@@ -214,15 +214,15 @@ class WeaTestCase(unittest.TestCase):
             'Chicago Ohare Intl Ap', 'USA', 41.98, -87.92, -6.0, 201.0)
         wea = Wea.from_ashrae_clear_sky(location, is_leap_year=True)
 
-        assert wea.diffuse_horizontal_radiation[1416].datetime.month == 2
-        assert wea.diffuse_horizontal_radiation[1416].datetime.day == 29
-        assert wea.diffuse_horizontal_radiation[1416].datetime.hour == 0
-        assert wea.diffuse_horizontal_radiation[1416].datetime.minute == 30
+        assert wea.diffuse_horizontal_irradiance[1416].datetime.month == 2
+        assert wea.diffuse_horizontal_irradiance[1416].datetime.day == 29
+        assert wea.diffuse_horizontal_irradiance[1416].datetime.hour == 0
+        assert wea.diffuse_horizontal_irradiance[1416].datetime.minute == 30
 
-        assert wea.diffuse_horizontal_radiation[1416 + 12].datetime.month == 2
-        assert wea.diffuse_horizontal_radiation[1416 + 12].datetime.day == 29
-        assert wea.diffuse_horizontal_radiation[1416 + 12].datetime.hour == 12
-        assert wea.diffuse_horizontal_radiation[1416 + 12].datetime.minute == 30
+        assert wea.diffuse_horizontal_irradiance[1416 + 12].datetime.month == 2
+        assert wea.diffuse_horizontal_irradiance[1416 + 12].datetime.day == 29
+        assert wea.diffuse_horizontal_irradiance[1416 + 12].datetime.hour == 12
+        assert wea.diffuse_horizontal_irradiance[1416 + 12].datetime.minute == 30
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@mostaphaRoudsari ,

This is an initial PR before I take the plunge into restructuring the DataCollection class.  Specifically, this one does not yet introduce breaking changes and it fleshes out a complete datatype class that is stored on the DataCollection header and can be used both for unit conversions and checks.  Specifically, I tried to keep this PR to just tackle three issues:
* Implement a new datatype class that is linked to units and holds methods for unit conversion
* Add the datatype class to the header of the DataCollection
* Add methods to the DataCollection for to_ip(), to_si(), to_unit(), and is_in_range()

The new datatype (currently called datatypenew.py) has been added alongside the existing datatype.py class for now to avoid breaking changes.  In the next PR that I send, I will introduce breaking changes, renaming datatypenew.py to datatype.py and abolishing the existing datatype.y and the DataPoint class.

I apologize that the PR ended up being a bigger than initially anticipated because of two other things that these changes affected:
* The EPW class required some changes as I moved information to be stored in the DataType class instead of the EPWFileds class.
* As I was developing code that to allow easy conversion between units, it became apparent that we really should be distinguishing between 'radiation (Wh/m2)', which is a unit of energy intensity and is cumulative over time and '[irradiance (W/m2)](https://en.wikipedia.org/wiki/Solar_irradiance)', which is a unit of energy flux and is not cumulative.  Realizing that the Wea data is supposed to be irradiance (as we recently discovered by looking at Wea's from finer timesteps), I have changed the names of Wea properties to use irradiance instead of radiation.

One thing to note about this implementation of datatypenew.py is that I have made the possible units for a given base data type extensible so that we are not locked into one or two units per data type.  This not only allows us to use esoteric IP units (like refrigeration tons for cooling or knots for wind speed) but it also allows us to convert easily between different metric units.  For example, if I want to compare energy use results out of E+ (in J or GJ) with the rates that the utility charges for electricity (in kWh) and compare both of these to radiation benefit studies (in Wh). These types of conversions are now easy to do.

While I feel strongly that this flexibility of units is important (especially after 3 years of working in a US office), the one thing this does mean is that the to_si() and to_ip() aren't always going to a single unit.  But I feel that this is actually what we want for a lot of cases.  For example, I would like to have Wh converted to Btu and have kWh converted to kBtu.  I would also like to have miles of visibility converted to km and not inches or feet.  To deal with the fact that these to_ip() and to_si() methods aren't always guaranteed to return the same unit, I added to_unit() methods that allow you to pass the destination unit that you would like the DataCollection converted to and it will automatically change everything to be in that unit.

I will send a PR to the ladybug-grasshopper repo showing how I imagine these API calls being used within components.

I am happy to add more checks to the unit conversions if you approve the general concept here.