### PR TITLE
fix(datatype): Putting epw missing, min, and max valules on EPW

### DIFF
--- a/ladybug/_datacollectionbase.py
+++ b/ladybug/_datacollectionbase.py
@@ -476,16 +476,11 @@ class BaseCollection(object):
             return result
 
     def is_in_data_type_range(self, raise_exception=True):
-        """Check if the Data Collection values are in permissable ranges for the data_type.
+        """Check if collection values are in physically possible ranges for the data_type.
 
         If this method returns False, the Data Collection's data is
         physically or mathematically impossible for the data_type."""
         return self._header.data_type.is_in_range(
-            self._values, self._header.unit, raise_exception)
-
-    def is_in_epw_range(self, raise_exception=True):
-        """Check if Data Collection values are in permissable ranges for EPW files."""
-        return self._header.data_type.is_in_range_epw(
             self._values, self._header.unit, raise_exception)
 
     @staticmethod

--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -998,7 +998,7 @@ class DailyCollection(BaseCollection):
         for d in xrange(1, 13):
             data_by_month[d] = []
         for v, doy in zip(self._values, self.datetimes):
-            dt = DateTime.from_hoy(doy * 24)
+            dt = DateTime.from_hoy(((doy - 1) * 24) + 1)
             data_by_month[dt.month].append(v)
         return data_by_month
 

--- a/ladybug/datatype/angle.py
+++ b/ladybug/datatype/angle.py
@@ -42,6 +42,3 @@ class Angle(DataTypeBase):
 class WindDirection(Angle):
     _name = 'Wind Direction'
     _abbreviation = 'WD'
-    _min_epw = 0
-    _max_epw = 360
-    _missing_epw = 999

--- a/ladybug/datatype/base.py
+++ b/ladybug/datatype/base.py
@@ -43,12 +43,6 @@ class DataTypeBase(object):
             when point_in_time is also True.
             (False Examples: Temperature, Irradiance, Illuminance)
             (True Examples: Energy, Radiation)
-        min_epw: Lower limit for the data type when it occurs in EPW files.
-            (Default: -inf)
-        max_epw: Upper limit for the data type when it occurs in EPW files.
-            (Default: +inf)
-        missing_epw: Missing value for the data type when it occurs in EPW files.
-            (Default: None)
     """
     _name = None
     _units = [None]
@@ -61,10 +55,6 @@ class DataTypeBase(object):
     _unit_descr = None
     _point_in_time = True
     _cumulative = False
-
-    _min_epw = float('-inf')
-    _max_epw = float('+inf')
-    _missing_epw = None
 
     _type_enumeration = None
 
@@ -146,14 +136,8 @@ class DataTypeBase(object):
             'to_si is not implemented on %s' % self.__class__.__name__
         )
 
-    def is_missing(self, value):
-        """Check if a value contains missing data when in an EPW."""
-        if value == self.missing_epw:
-            return True
-        return False
-
     def is_in_range(self, values, unit=None, raise_exception=True):
-        """Check if a list of values is within acceptable ranges.
+        """Check if a list of values is within physically/mathematically possible range.
 
         Args:
             values: A list of values.
@@ -176,43 +160,6 @@ class DataTypeBase(object):
             maximum = eval(max_statement, namespace)
 
         for value in values:
-            if value < minimum or value > maximum:
-                if not raise_exception:
-                    return False
-                else:
-                    raise ValueError(
-                        '{0} should be between {1} and {2}. Got {3}'.format(
-                            self.__class__.__name__, self.min, self.max, value
-                        )
-                    )
-        return True
-
-    def is_in_range_epw(self, values, unit=None, raise_exception=True):
-        """Check if a list of values is within acceptable ranges for an EPW file.
-
-        Args:
-            values: A list of values.
-            unit: The unit of the values.  If not specified, the default metric
-                unit will be assumed.
-            raise_exception: Set to True to raise an exception if not in range.
-        """
-        self._is_numeric(values)
-        if unit is None or unit == self.units[0]:
-            minimum = self.min_epw
-            maximum = self.max_epw
-        else:
-            namespace = {'self': self}
-            self.is_unit_acceptable(unit, True)
-            min_statement = "self._{}_to_{}(self.min_epw)".format(
-                self._clean(self.units[0]), self._clean(unit))
-            max_statement = "self._{}_to_{}(self.max_epw)".format(
-                self._clean(self.units[0]), self._clean(unit))
-            minimum = eval(min_statement, namespace)
-            maximum = eval(max_statement, namespace)
-
-        for value in values:
-            if self.is_missing(value):
-                continue
             if value < minimum or value > maximum:
                 if not raise_exception:
                     return False
@@ -327,21 +274,6 @@ class DataTypeBase(object):
     def cumulative(self):
         """Whether the data type is cumulative."""
         return self._cumulative
-
-    @property
-    def min_epw(self):
-        """Minimum acceptable value for an EPW."""
-        return self._min_epw
-
-    @property
-    def max_epw(self):
-        """Maxmimum acceptable value for an EPW."""
-        return self._max_epw
-
-    @property
-    def missing_epw(self):
-        """Missing value for an EPW."""
-        return self._missing_epw
 
     @property
     def isDataType(self):

--- a/ladybug/datatype/energyflux.py
+++ b/ladybug/datatype/energyflux.py
@@ -83,8 +83,6 @@ class EffectiveRadiantField(EnergyFlux):
 class Irradiance(EnergyFlux):
     _min = 0
     _abbreviation = 'Qsolar'
-    _min_epw = 0
-    _missing_epw = 9999
 
     @property
     def isIrradiance(self):

--- a/ladybug/datatype/energyintensity.py
+++ b/ladybug/datatype/energyintensity.py
@@ -63,8 +63,6 @@ class EnergyIntensity(DataTypeBase):
 class Radiation(EnergyIntensity):
     _min = 0
     _abbreviation = 'Esolar'
-    _min_epw = 0
-    _missing_epw = 9999
 
     @property
     def isRadiation(self):

--- a/ladybug/datatype/fraction.py
+++ b/ladybug/datatype/fraction.py
@@ -63,9 +63,6 @@ class PercentagePeopleDissatisfied(Fraction):
 class RelativeHumidity(Fraction):
     _min = 0
     _abbreviation = 'RH'
-    _min_epw = 0
-    _max_epw = 1.1
-    _missing_epw = 999
 
 
 class HumidityRatio(Fraction):
@@ -79,9 +76,6 @@ class TotalSkyCover(Fraction):
     _min = 0
     _max = 1
     _abbreviation = 'CC'
-    _min_epw = 0
-    _max_epw = 1
-    _missing_epw = 99
 
 
 class OpaqueSkyCover(Fraction):
@@ -89,32 +83,20 @@ class OpaqueSkyCover(Fraction):
     _min = 0
     _max = 1
     _abbreviation = 'OSC'
-    _min_epw = 0
-    _max_epw = 1
-    _missing_epw = 99
 
 
 class AerosolOpticalDepth(Fraction):
     _min = 0
     _max = 1
     _abbreviation = 'AOD'
-    _min_epw = 0
-    _max_epw = 1
-    _missing_epw = 0.999
 
 
 class Albedo(Fraction):
     _min = 0
     _max = 1
     _abbreviation = 'a'
-    _min_epw = 0
-    _max_epw = 1
-    _missing_epw = 0.999
 
 
 class LiquidPrecipitationQuantity(Fraction):
     _min = 0
     _abbreviation = 'LPQ'
-    _min_epw = 0
-    _max_epw = 1
-    _missing_epw = 99

--- a/ladybug/datatype/generic.py
+++ b/ladybug/datatype/generic.py
@@ -8,9 +8,8 @@ from .base import DataTypeBase
 class GenericType(DataTypeBase):
     """Type for any data type that is not currently implemented."""
     def __init__(self, name, unit, min=float('-inf'), max=float('+inf'),
-                 abbreviation=None, unit_descr='', point_in_time=True,
-                 cumulative=False, min_epw=float('-inf'), max_epw=float('+inf'),
-                 missing_epw=None):
+                 abbreviation=None, unit_descr=None, point_in_time=True,
+                 cumulative=False):
         """Initalize Generic Type.
 
         Args:
@@ -21,8 +20,10 @@ class GenericType(DataTypeBase):
             max: Optional upper limit for the data type, values above which should be
                 physically or mathematically impossible. (Default: +inf)
             abbreviation: An optional abbreviation for the data type as text.
-            unit_descr: An optional description of the units if numerical values
-                of these units relate to specific categories.
+            unit_descr: An optional dictionary describing categories that the numerical
+                values of the units relate to. For example:
+                {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+                {0: 'False', 1: 'True'}
             point_in_time: Boolean to note whether the data type represents conditions
                 at a single instant in time (True) as opposed to being an average or
                 accumulation over time (False) when it is found in hourly lists of data.
@@ -31,12 +32,6 @@ class GenericType(DataTypeBase):
                 is represented over time (True) or it can only be averaged over time
                 to be meaningful (False). Note that cumulative cannot be True
                 when point_in_time is also True. (Default: False)
-            min_epw: Lower limit for the data type when it occurs in EPW files.
-                (Default: -inf)
-            max_epw: Upper limit for the data type when it occurs in EPW files.
-                (Default: +inf)
-            missing_epw: Missing value for the data type when it occurs in EPW files.
-                (Default: None)
         """
         assert isinstance(name, str), 'name must be a string. Got {}.'.format(type(name))
         assert isinstance(unit, str), 'unit must be a string. Got {}.'.format(type(unit))
@@ -47,8 +42,9 @@ class GenericType(DataTypeBase):
         if abbreviation is not None:
             assert isinstance(abbreviation, str), 'abbreviation must be a ' \
                 'string. Got {}.'.format(type(abbreviation))
-        assert isinstance(unit_descr, str), 'unit_descr must be a ' \
-            'string. Got {}.'.format(type(unit_descr))
+        if unit_descr is not None:
+            assert isinstance(unit_descr, dict), 'unit_descr must be a ' \
+                'dictionary. Got {}.'.format(type(unit_descr))
         assert isinstance(point_in_time, bool), 'point_in_time must be a ' \
             'boolean. Got {}.'.format(type(point_in_time))
         assert isinstance(cumulative, bool), 'cumulative must be a ' \
@@ -56,13 +52,6 @@ class GenericType(DataTypeBase):
         if point_in_time is True:
             assert cumulative is False, 'cumulative cannot be True when ' \
                 'point_in_time is also True.'
-        assert isinstance(min_epw, (float, int)), 'min_epw must be a number. ' \
-            'Got {}.'.format(type(min_epw))
-        assert isinstance(max_epw, (float, int)), 'max_epw must be a number. ' \
-            'Got {}.'.format(type(max_epw))
-        if missing_epw is not None:
-            assert isinstance(missing_epw, (float, int)), 'missing_epw must be' \
-                'a number .Got {}.'.format(type(missing_epw))
 
         self._name = name
         self._units = [unit]
@@ -72,9 +61,6 @@ class GenericType(DataTypeBase):
         self._unit_descr = unit_descr
         self._point_in_time = point_in_time
         self._cumulative = cumulative
-        self._min_epw = min_epw
-        self._max_epw = max_epw
-        self._missing_epw = missing_epw
 
     def to_ip(self, values, from_unit):
         """Return values in IP and the units to which the values have been converted."""

--- a/ladybug/datatype/illuminance.py
+++ b/ladybug/datatype/illuminance.py
@@ -13,8 +13,6 @@ class Illuminance(DataTypeBase):
     _min = 0
     _abbreviation = 'Ev'
     _point_in_time = False
-    _min_epw = 0
-    _missing_epw = 999999  # note will be missing if >= 999900
 
     def _lux_to_fc(self, value):
         return value / 10.7639

--- a/ladybug/datatype/luminance.py
+++ b/ladybug/datatype/luminance.py
@@ -13,8 +13,6 @@ class Luminance(DataTypeBase):
     _min = 0
     _abbreviation = 'Lv'
     _point_in_time = False
-    _min_epw = 0
-    _missing_epw = 9999  # note will be missing if >= 999900
 
     def _cd_m2_to_cd_ft2(self, value):
         return value / 10.7639

--- a/ladybug/datatype/pressure.py
+++ b/ladybug/datatype/pressure.py
@@ -76,6 +76,3 @@ class Pressure(DataTypeBase):
 class AtmosphericStationPressure(Pressure):
     _min = 0
     _abbreviation = 'Patm'
-    _min_epw = 31000
-    _max_epw = 120000
-    _missing_epw = 999999

--- a/ladybug/datatype/speed.py
+++ b/ladybug/datatype/speed.py
@@ -63,9 +63,6 @@ class Speed(DataTypeBase):
 
 class WindSpeed(Speed):
     _abbreviation = 'WS'
-    _min_epw = 0
-    _max_epw = 40
-    _missing_epw = 999
 
 
 class AirSpeed(Speed):

--- a/ladybug/datatype/temperature.py
+++ b/ladybug/datatype/temperature.py
@@ -51,16 +51,10 @@ class Temperature(DataTypeBase):
 
 class DryBulbTemperature(Temperature):
     _abbreviation = 'DBT'
-    _min_epw = -70
-    _max_epw = 70
-    _missing_epw = 99.9
 
 
 class DewPointTemperature(Temperature):
     _abbreviation = 'DPT'
-    _min_epw = -70
-    _max_epw = 70
-    _missing_epw = 99.9
 
 
 class WetBulbTemperature(Temperature):

--- a/ladybug/epw.py
+++ b/ladybug/epw.py
@@ -164,8 +164,8 @@ class EPW(object):
         # generate missing hourly data
         calc_length = len(analysis_period.datetimes)
         for field_number in xrange(6, epw_obj._num_of_fields):
-            data_type = EPWFields.field_by_number(field_number).name
-            mis_val = data_type.missing_epw if data_type.missing_epw is not None else 0
+            field = EPWFields.field_by_number(field_number)
+            mis_val = field.missing if field.missing is not None else 0
             for dt in xrange(calc_length):
                 epw_obj._data[field_number].append(mis_val)
 
@@ -1425,150 +1425,201 @@ class EPWFields(object):
 
         6: {'name': temperature.DryBulbTemperature(),
             'type': float,
-            'unit': 'C'
+            'unit': 'C',
+            'min': -70,
+            'max': 70,
+            'missing': 99.9
             },
 
         7: {'name': temperature.DewPointTemperature(),
             'type': float,
-            'unit': 'C'
+            'unit': 'C',
+            'min': -70,
+            'max': 70,
+            'missing': 99.9
             },
 
         8: {'name': fraction.RelativeHumidity(),
             'type': int,
-            'unit': '%'
+            'unit': '%',
+            'missing': 999,
+            'min': 0,
+            'max': 110
             },
 
         9: {'name': pressure.AtmosphericStationPressure(),
             'type': int,
-            'unit': 'Pa'
+            'unit': 'Pa',
+            'missing': 999999,
+            'min': 31000,
+            'max': 120000
             },
 
         10: {'name': energyintensity.ExtraterrestrialHorizontalRadiation(),
              'type': int,
-             'unit': 'Wh/m2'
+             'unit': 'Wh/m2',
+             'missing': 9999,
+             'min': 0
              },
 
         11: {'name': energyintensity.ExtraterrestrialDirectNormalRadiation(),
              'type': int,
-             'unit': 'Wh/m2'
+             'unit': 'Wh/m2',
+             'missing': 9999,
+             'min': 0
              },
 
         12: {'name': energyflux.HorizontalInfraredRadiationIntensity(),
              'type': int,
-             'unit': 'W/m2'
+             'unit': 'W/m2',
+             'missing': 9999,
+             'min': 0
              },
 
         13: {'name': energyintensity.GlobalHorizontalRadiation(),
              'type': int,
-             'unit': 'Wh/m2'
+             'unit': 'Wh/m2',
+             'missing': 9999,
+             'min': 0
              },
 
         14: {'name': energyintensity.DirectNormalRadiation(),
              'type': int,
-             'unit': 'Wh/m2'
+             'unit': 'Wh/m2',
+             'missing': 9999,
+             'min': 0
              },
 
         15: {'name': energyintensity.DiffuseHorizontalRadiation(),
              'type': int,
-             'unit': 'Wh/m2'
+             'unit': 'Wh/m2',
+             'missing': 9999,
+             'min': 0
              },
 
         16: {'name': illuminance.GlobalHorizontalIlluminance(),
              'type': int,
-             'unit': 'lux'
+             'unit': 'lux',
+             'missing': 999999,  # will be missing if >= 999900
+             'min': 0
              },
 
         17: {'name': illuminance.DirectNormalIlluminance(),
              'type': int,
-             'unit': 'lux'
+             'unit': 'lux',
+             'missing': 999999,  # will be missing if >= 999900
+             'min': 0
              },
 
         18: {'name': illuminance.DiffuseHorizontalIlluminance(),
              'type': int,
-             'unit': 'lux'
+             'unit': 'lux',
+             'missing': 999999,  # will be missing if >= 999900
+             'min': 0
              },
 
         19: {'name': luminance.ZenithLuminance(),
              'type': int,
-             'unit': 'cd/m2'
+             'unit': 'cd/m2',
+             'missing': 9999,  # will be missing if >= 9999
+             'min': 0
              },
 
         20: {'name': angle.WindDirection(),
              'type': int,
-             'unit': 'degrees'
+             'unit': 'degrees',
+             'missing': 999,
+             'min': 0,
+             'max': 360
              },
 
         21: {'name': speed.WindSpeed(),
              'type': float,
-             'unit': 'm/s'
+             'unit': 'm/s',
+             'missing': 999,
+             'min': 0,
+             'max': 40
              },
 
         22: {'name': fraction.TotalSkyCover(),  # used if Horizontal IR is missing
              'type': int,
-             'unit': 'tenths'
+             'unit': 'tenths',
+             'missing': 99,
+             'min': 0,
+             'max': 10
              },
 
         23: {'name': fraction.OpaqueSkyCover(),  # used if Horizontal IR is missing
              'type': int,
-             'unit': 'tenths'
+             'unit': 'tenths',
+             'missing': 99
              },
 
         24: {'name': distance.Visibility(),
              'type': float,
-             'unit': 'km'
+             'unit': 'km',
+             'missing': 9999
              },
 
         25: {'name': distance.CeilingHeight(),
              'type': int,
-             'unit': 'm'
+             'unit': 'm',
+             'missing': 99999
              },
 
         26: {'name': generic.GenericType(name='Present Weather Observation',
-                                         unit='observation', missing_epw=9),
+                                         unit='observation'),
              'type': int,
-             'unit': 'observation'
+             'unit': 'observation',
+             'missing': 9
              },
 
-        27: {'name': generic.GenericType(name='Present Weather Codes',
-                                         unit='codes', missing_epw=999999999),
+        27: {'name': generic.GenericType(name='Present Weather Codes', unit='codes'),
              'type': int,
-             'unit': 'codes'
+             'unit': 'codes',
+             'missing': 999999999
              },
 
         28: {'name': distance.PrecipitableWater(),
              'type': int,
-             'unit': 'mm'
+             'unit': 'mm',
+             'missing': 999
              },
 
         29: {'name': fraction.AerosolOpticalDepth(),
              'type': float,
-             'unit': 'fraction'
+             'unit': 'fraction',
+             'missing': 999
              },
 
         30: {'name': distance.SnowDepth(),
              'type': int,
-             'unit': 'cm'
+             'unit': 'cm',
+             'missing': 999
              },
 
-        31: {'name': generic.GenericType(name='Days Since Last Snowfall',
-                                         unit='day', missing_epw=99),
+        31: {'name': generic.GenericType(name='Days Since Last Snowfall', unit='day'),
              'type': int,
-             'unit': 'day'
+             'unit': 'day',
+             'missing': 99
              },
 
         32: {'name': fraction.Albedo(),
              'type': float,
-             'unit': 'fraction'
+             'unit': 'fraction',
+             'missing': 999
              },
 
         33: {'name': distance.LiquidPrecipitationDepth(),
              'type': float,
-             'unit': 'mm'
+             'unit': 'mm',
+             'missing': 999
              },
 
         34: {'name': fraction.LiquidPrecipitationQuantity(),
              'type': float,
-             'unit': 'fraction'
+             'unit': 'fraction',
+             'missing': 99
              }
     }
 
@@ -1631,6 +1682,7 @@ class EPWField(object):
         name: Name of the field.
         type: field value type (e.g. int, float, str)
         unit: Field unit.
+        missing: Missing value for the data type in EPW files.
     """
 
     def __init__(self, field_dict):
@@ -1640,3 +1692,7 @@ class EPWField(object):
             self.unit = field_dict['unit']
         else:
             self.unit = None
+        if 'missing' in field_dict:
+            self.missing = field_dict['missing']
+        else:
+            self.missing = None

--- a/tests/datacollection_test.py
+++ b/tests/datacollection_test.py
@@ -791,7 +791,7 @@ class DataCollectionTestCase(unittest.TestCase):
         """Test the average monthly method."""
         header = Header(Temperature(), 'C', AnalysisPeriod())
         values = list(xrange(365))
-        dc = DailyCollection(header, values, values)
+        dc = DailyCollection(header, values, AnalysisPeriod().doys_int)
         new_dc = dc.average_monthly()
         assert isinstance(new_dc, MonthlyCollection)
         assert len(new_dc) == 12
@@ -804,7 +804,7 @@ class DataCollectionTestCase(unittest.TestCase):
         """Test the total monthly method."""
         header = Header(Temperature(), 'C', AnalysisPeriod())
         values = list(xrange(365))
-        dc = DailyCollection(header, values, values)
+        dc = DailyCollection(header, values, AnalysisPeriod().doys_int)
         new_dc = dc.total_monthly()
         assert isinstance(new_dc, MonthlyCollection)
         assert len(new_dc) == 12
@@ -817,7 +817,7 @@ class DataCollectionTestCase(unittest.TestCase):
         """Test the percentile monthly method."""
         header = Header(Temperature(), 'C', AnalysisPeriod())
         values = list(xrange(365))
-        dc = DailyCollection(header, values, values)
+        dc = DailyCollection(header, values, AnalysisPeriod().doys_int)
         new_dc = dc.percentile_monthly(25)
         assert isinstance(new_dc, MonthlyCollection)
         assert len(new_dc) == 12

--- a/tests/datacollection_test.py
+++ b/tests/datacollection_test.py
@@ -1142,23 +1142,6 @@ class DataCollectionTestCase(unittest.TestCase):
         assert dc3.is_in_data_type_range(raise_exception=False) is True
         assert dc4.is_in_data_type_range(raise_exception=False) is False
 
-    def test_is_in_range_epw(self):
-        """Test the function to check whether values are in range for an EPW."""
-        header1 = Header(RelativeHumidity(), '%', AnalysisPeriod())
-        header2 = Header(RelativeHumidity(), 'fraction', AnalysisPeriod())
-        val1 = [50] * 8760
-        val2 = [150] * 8760
-        val3 = [0.5] * 8760
-        val4 = [1.5] * 8760
-        dc1 = HourlyContinuousCollection(header1, val1)
-        dc2 = HourlyContinuousCollection(header1, val2)
-        dc3 = HourlyContinuousCollection(header2, val3)
-        dc4 = HourlyContinuousCollection(header2, val4)
-        assert dc1.is_in_epw_range(raise_exception=False) is True
-        assert dc2.is_in_epw_range(raise_exception=False) is False
-        assert dc3.is_in_epw_range(raise_exception=False) is True
-        assert dc4.is_in_epw_range(raise_exception=False) is False
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
After realizing that the code for the epw values on the data type objects did not pass the smell test, we are putting them back on the EPW field object.  I now agree that this makes more sense and we never should have moved them.

Resolves #118 