### PR TITLE
feat(date, time): Add objects for Date and Time

### DIFF
--- a/ladybug/analysisperiod.py
+++ b/ladybug/analysisperiod.py
@@ -165,7 +165,7 @@ class AnalysisPeriod(object):
         """
         if not analysis_period:
             return cls()
-        elif hasattr(analysis_period, 'isAnalysisPeriod'):
+        elif isinstance(analysis_period, AnalysisPeriod):
             return analysis_period
         elif isinstance(analysis_period, str):
             try:
@@ -447,11 +447,8 @@ class AnalysisPeriod(object):
         if isinstance(other, self.__class__):
             if (self.st_time, self.end_time, self.timestep, self.is_leap_year) == \
                     (other.st_time, other.end_time, other.timestep, other.is_leap_year):
-                        return True
-            else:
-                return False
-        else:
-            return False
+                return True
+        return False
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/ladybug/dt.py
+++ b/ladybug/dt.py
@@ -2,19 +2,23 @@
 """Ladybug datetime."""
 from __future__ import division
 
-from datetime import datetime
+from datetime import datetime, date, time
 
 
 class DateTime(datetime):
     """Create Ladybug Date time.
 
-    Args:
-        month: A value for month between 1-12 (Defualt: 1).
-        day: A value for day between 1-31 (Defualt: 1).
-        hour: A value for hour between 0-23 (Defualt: 0).
-        minute: A value for month between 0-59 (Defualt: 0).
-        leap_year: A boolean to indicate if datetime is for a leap year
-            (Default: False).
+    Properties:
+        month
+        day
+        hour
+        minute
+        leap_year
+        doy
+        hoy
+        moy
+        int_hoy
+        float_hour
     """
 
     __slots__ = ()
@@ -31,7 +35,7 @@ class DateTime(datetime):
                 (Default: False).
         """
         year = 2016 if leap_year else 2017
-        hour, minute = cls._calculate_hour_and_minute(hour + minute / 60.0)
+        hour, minute = Time._calculate_hour_and_minute(hour + minute / 60.0)
         try:
             return datetime.__new__(cls, year, month, day, hour, minute)
         except ValueError as e:
@@ -51,23 +55,12 @@ class DateTime(datetime):
                 'minute': A value for month between 0-59. (Defualt: 0)
             }
         """
-        if 'month' not in data:
-            data['month'] = 1
-
-        if 'day' not in data:
-            data['day'] = 1
-
-        if 'hour' not in data:
-            data['hour'] = 0
-
-        if 'minute' not in data:
-            data['minute'] = 0
-
-        if 'year' not in data:
-            data['year'] = 2017
-
-        leap_year = True if int(data['year']) == 2016 else False
-        return cls(data['month'], data['day'], data['hour'], data['minute'], leap_year)
+        month = data['month'] if 'month' in data else 1
+        day = data['day'] if 'day' in data else 1
+        hour = data['hour'] if 'hour' in data else 0
+        minute = data['minute'] if 'minute' in data else 0
+        leap_year = data['leap_year'] if 'leap_year' in data else False
+        return cls(month, day, hour, minute, leap_year)
 
     @classmethod
     def from_hoy(cls, hoy, leap_year=False):
@@ -75,6 +68,8 @@ class DateTime(datetime):
 
         Args:
             hoy: A float value 0 <= and < 8760
+            leap_year: Boolean to note whether the Date Time is a part of a
+                leap year. Default: False.
         """
         return cls.from_moy(round(hoy * 60), leap_year)
 
@@ -84,6 +79,8 @@ class DateTime(datetime):
 
         Args:
             moy: An integer value 0 <= and < 525600
+            leap_year: Boolean to note whether the Date Time is a part of a
+                leap year. Default: False.
         """
         if not leap_year:
             num_of_minutes_until_month = (0, 44640, 84960, 129600, 172800, 217440,
@@ -95,9 +92,10 @@ class DateTime(datetime):
                                           305280 + 1440, 349920 + 1440, 393120 + 1440,
                                           437760 + 1440, 480960 + 1440, 525600 + 1440)
         # find month
-        for monthCount in range(12):
-            if int(moy) < num_of_minutes_until_month[monthCount + 1]:
-                month = monthCount + 1
+        moy = int(moy)
+        for month_count in range(12):
+            if moy < num_of_minutes_until_month[month_count + 1]:
+                month = month_count + 1
                 break
         try:
             day = int((moy - num_of_minutes_until_month[month - 1]) / (60 * 24)) + 1
@@ -115,17 +113,33 @@ class DateTime(datetime):
     def from_date_time_string(cls, datetime_string, leap_year=False):
         """Create Ladybug DateTime from a DateTime string.
 
-        Usage:
+        Args:
+            datetime_string: A text string representing a DateTime
+                (ie. "21 Jun 12:00")
+            leap_year: Boolean to note whether the Date Time is a part of a
+                leap year. Default: False.
 
+        Usage:
             dt = DateTime.from_date_time_string("31 Dec 12:00")
         """
         dt = datetime.strptime(datetime_string, '%d %b %H:%M')
         return cls(dt.month, dt.day, dt.hour, dt.minute, leap_year)
 
+    @classmethod
+    def from_date_and_time(cls, date, time):
+        """Create Ladybug DateTime from a Date and a Time object.
+
+        Args:
+            date: A ladybug Date object.
+            time: A ladybug Time object.
+        """
+        leap_year = True if date.year % 4 == 0 else False
+        return cls(date.month, date.day, time.hour, time.minute, leap_year)
+
     @property
-    def isDateTime(self):
-        """Check if data is ladybug data."""
-        return True
+    def leap_year(self):
+        """Boolean to note whether DateTime belongs to a leap year or not."""
+        return self.year == 2016
 
     @property
     def doy(self):
@@ -155,14 +169,13 @@ class DateTime(datetime):
         """
         return (self.doy - 1) * 24 + self.hour
 
-    @staticmethod
-    def _calculate_hour_and_minute(float_hour):
-        """Calculate hour and minutes as integers from a float hour."""
-        hour, minute = int(float_hour), int(round((float_hour - int(float_hour)) * 60))
-        if minute == 60:
-            return hour + 1, 0
-        else:
-            return hour, minute
+    def date(self):
+        """Get a Date object associated with this DateTime."""
+        return Date(self.month, self.day, self.leap_year)
+
+    def time(self):
+        """Get a Time object associated with this DateTime."""
+        return Time(self.hour, self.minute)
 
     def add_minute(self, minute):
         """Create a new DateTime after the minutes are added.
@@ -185,7 +198,7 @@ class DateTime(datetime):
         """Create a new DateTime from this time + timedelta.
 
         Args:
-            hours: A float value in hours (e.g. .5 = half an hour)
+            hour: A float value in hours (e.g. .5 = half an hour)
         """
         return self.add_minute(hour * 60)
 
@@ -201,17 +214,19 @@ class DateTime(datetime):
         """Return a simplified string."""
         return self.strftime('%d_%b_%H_%M').replace("_", separator)
 
-    def __str__(self):
-        """Return date time as a string."""
-        return self.strftime('%d %b %H:%M')
-
     def to_dict(self):
         """Get datetime as a dictionary."""
-        return {'year': self.year,
-                'month': self.month,
+        base = {'month': self.month,
                 'day': self.day,
                 'hour': self.hour,
                 'minute': self.minute}
+        if self.leap_year:
+            base['leap_year'] = True
+        return base
+
+    def __str__(self):
+        """Return date time as a string."""
+        return self.strftime('%d %b %H:%M')
 
     def ToString(self):
         """Overwrite .NET ToString."""
@@ -219,4 +234,211 @@ class DateTime(datetime):
 
     def __repr__(self):
         """Return date time as a string."""
+        return self.__str__()
+
+
+class Date(date):
+    """Ladybug Date.
+
+    Properties:
+        month
+        day
+        leap_year
+        doy
+    """
+
+    __slots__ = ()
+
+    def __new__(cls, month=1, day=1, leap_year=False):
+        """Create Ladybug Date.
+
+        Args:
+            month: A value for month between 1-12 (Defualt: 1).
+            day: A value for day between 1-31 (Defualt: 1).
+            leap_year: A boolean to indicate if date is for a leap year
+                (Default: False).
+        """
+        year = 2016 if leap_year else 2017
+        try:
+            return date.__new__(cls, year, month, day)
+        except ValueError as e:
+            raise ValueError("{}:\n\t({}/{})(m/d)".format(e, month, day))
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create date from a dictionary.
+
+        Args:
+            data: {
+                'month': A value for month between 1-12. (Defualt: 1)
+                'day': A value for day between 1-31. (Defualt: 1)
+            }
+        """
+        month = data['month'] if 'month' in data else 1
+        day = data['day'] if 'day' in data else 1
+        leap_year = data['leap_year'] if 'leap_year' in data else False
+        return cls(month, day, leap_year)
+
+    @classmethod
+    def from_doy(cls, doy, leap_year=False):
+        """Create Ladybug Date from an day of the year.
+
+        Args:
+            doy: An int value 0 <= and < 366
+        """
+        if not leap_year:
+            days_until_month = (0, 31, 59, 90, 120, 151, 181,
+                                212, 243, 273, 304, 334, 365)
+        else:
+            days_until_month = (0, 31, 60, 91, 121, 152, 182,
+                                213, 244, 274, 305, 335, 366)
+
+        doy = int(doy)
+        for month_count in range(12):  # find month
+            if doy < days_until_month[month_count + 1]:
+                month = month_count + 1
+                break
+        try:
+            day = int(doy - days_until_month[month - 1])
+        except UnboundLocalError:
+            raise ValueError(
+                "doy must be positive and smaller than 366. Invalid input %d" % (doy)
+            )
+        return cls(month, day, leap_year)
+
+    @classmethod
+    def from_date_string(cls, date_string, leap_year=False):
+        """Create Ladybug Date from a Date string.
+
+        Usage:
+
+            dt = Date.from_date_string("31 Dec")
+        """
+        dt = datetime.strptime(date_string, '%d %b')
+        return cls(dt.month, dt.day, leap_year)
+
+    @property
+    def leap_year(self):
+        """Boolean to note whether Date belongs to a leap year or not."""
+        return self.year == 2016
+
+    @property
+    def doy(self):
+        """Calculate day of the year for this date."""
+        return self.timetuple().tm_yday
+
+    def to_dict(self):
+        """Get date as a dictionary."""
+        base = {'month': self.month, 'day': self.day}
+        if self.leap_year:
+            base['leap_year'] = True
+        return base
+
+    def __str__(self):
+        """Return date as a string."""
+        return self.strftime('%d %b')
+
+    def ToString(self):
+        """Overwrite .NET ToString."""
+        return self.__str__()
+
+    def __repr__(self):
+        """Return date as a string."""
+        return self.__str__()
+
+
+class Time(time):
+    """Create Ladybug Time.
+
+    Properties:
+        hour
+        minute
+        mod
+        float_hour
+    """
+
+    __slots__ = ()
+
+    def __new__(cls, hour=0, minute=0):
+        """Create Ladybug Time.
+
+        Args:
+            hour: A value for hour between 0-23 (Defualt: 0).
+            minute: A value for month between 0-59 (Defualt: 0).
+        """
+        hour, minute = cls._calculate_hour_and_minute(hour + minute / 60.0)
+        try:
+            return time.__new__(cls, hour, minute)
+        except ValueError as e:
+            raise ValueError("{}:\n\t({}:{})(h:m)".format(e, hour, minute))
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create time from a dictionary.
+
+        Args:
+            data: {
+                'hour': A value for hour between 0-23. (Defualt: 0)
+                'minute': A value for month between 0-59. (Defualt: 0)
+            }
+        """
+        hour = data['hour'] if 'hour' in data else 0
+        minute = data['minute'] if 'minute' in data else 0
+        return cls(hour, minute)
+
+    @classmethod
+    def from_mod(cls, mod):
+        """Create Ladybug Time from a minute of the day.
+
+        Args:
+            mod: An int value 0 <= and < 1440
+        """
+        hour, minute = cls._calculate_hour_and_minute(mod / 60.0)
+        return cls(hour, minute)
+
+    @classmethod
+    def from_time_string(cls, time_string, leap_year=False):
+        """Create Ladybug Time from a Time string.
+
+        Usage:
+
+            dt = Time.from_time_string("12:00")
+        """
+        dt = datetime.strptime(time_string, '%H:%M')
+        return cls(dt.hour, dt.minute)
+
+    @property
+    def mod(self):
+        """Calculate minute of the day for this time."""
+        return self.hour * 60 + self.minute
+
+    @property
+    def float_hour(self):
+        """Get hour and minute as a float value (e.g. 6.25 for 6:15)."""
+        return self.hour + self.minute / 60.0
+
+    def to_dict(self):
+        """Get time as a dictionary."""
+        return {'hour': self.hour, 'minute': self.minute}
+
+    @staticmethod
+    def _calculate_hour_and_minute(float_hour):
+        """Calculate hour and minutes as integers from a float hour."""
+        hour = int(float_hour)
+        minute = int(round((float_hour - hour) * 60))
+        if minute == 60:
+            return hour + 1, 0
+        else:
+            return hour, minute
+
+    def __str__(self):
+        """Return time as a string."""
+        return self.strftime('%H:%M')
+
+    def ToString(self):
+        """Overwrite .NET ToString."""
+        return self.__str__()
+
+    def __repr__(self):
+        """Return time as a string."""
         return self.__str__()

--- a/ladybug/header.py
+++ b/ladybug/header.py
@@ -35,14 +35,14 @@ class Header(object):
             metadata: Optional dictionary of additional metadata,
                 containing information such as 'source', 'city', or 'zone'.
         """
-        assert hasattr(data_type, 'isDataType'), \
+        assert isinstance(data_type, DataTypeBase), \
             'data_type must be a Ladybug DataType. Got {}'.format(type(data_type))
         if unit is None:
             unit = data_type.units[0]
         else:
             data_type.is_unit_acceptable(unit)
         if analysis_period is not None:
-            assert hasattr(analysis_period, 'isAnalysisPeriod'), \
+            assert isinstance(analysis_period, AnalysisPeriod), \
                 'analysis_period must be a Ladybug AnalysisPeriod. Got {}'.format(
                     type(analysis_period))
         if metadata is not None:

--- a/ladybug/location.py
+++ b/ladybug/location.py
@@ -72,7 +72,7 @@ class Location(object):
         if not location:
             return cls()
         try:
-            if hasattr(location, 'isLocation'):
+            if isinstance(location, Location):
                 # Ladybug location
                 return location
 

--- a/ladybug/sunpath.py
+++ b/ladybug/sunpath.py
@@ -700,7 +700,7 @@ class Sun(object):
     def __init__(self, datetime, altitude, azimuth, is_solar_time,
                  is_daylight_saving, north_angle, data=None):
         """Init sun."""
-        assert hasattr(datetime, 'isDateTime'), \
+        assert isinstance(datetime, DateTime), \
             "datetime must be a DateTime (not {})".format(type(datetime))
         self._datetime = datetime  # read-only
 

--- a/tests/dt_test.py
+++ b/tests/dt_test.py
@@ -1,0 +1,166 @@
+# coding=utf-8
+from ladybug.dt import DateTime, Date, Time
+
+
+def test_date_time_init():
+    """Test the init method for DateTime and basic properties."""
+    dt1 = DateTime(6, 21, 12)
+    dt2 = DateTime(6, 21, 12)
+    dt3 = DateTime(6, 21, 12, leap_year=True)
+    dt4 = DateTime(6, 21, 13)
+    str(dt1)  # test the string representation of Datetime
+
+    assert dt1.month == 6
+    assert dt1.day == 21
+    assert dt1.hour == 12
+    assert dt1.minute == 0
+    assert not dt1.leap_year
+    assert dt1.doy == 172
+    assert dt1.hoy == 4116
+    assert dt1.moy == 246960
+    assert isinstance(dt1.int_hoy, int)
+    assert dt1.int_hoy == 4116
+    assert dt1.float_hour == 12.0
+    assert dt1.date() == Date(6, 21)
+    assert dt1.time() == Time(12, 0)
+
+    assert dt1 == dt2
+    assert dt1 != dt3
+    assert dt1 != dt4
+
+    assert sorted([dt4, dt1]) == [dt1, dt4]
+
+
+def test_date_time_to_from_dict():
+    """Test the dict methods for DateTime."""
+    dt1 = DateTime(6, 21, 12)
+    dt_dict = dt1.to_dict()
+    rebuilt_dt = DateTime.from_dict(dt_dict)
+    assert dt1 == rebuilt_dt
+    assert rebuilt_dt.to_dict() == dt_dict
+
+
+def test_to_from_date_time_string():
+    """Test the from_date_time_string method for DateTime."""
+    dt1 = DateTime(6, 21, 12)
+    dt_str = str(dt1)
+    rebuilt_dt = DateTime.from_date_time_string(dt_str)
+    assert rebuilt_dt == dt1
+    assert str(rebuilt_dt) == dt_str
+
+
+def test_date_time_from_hoy():
+    """Test the from_hoy method for DateTime and basic properties."""
+    dt1 = DateTime.from_hoy(4116)
+    assert dt1 == DateTime(6, 21, 12)
+    dt2 = DateTime.from_hoy(4116, leap_year=True)
+    assert dt2 == DateTime(6, 20, 12, leap_year=True)
+
+
+def test_date_time_from_moy():
+    """Test the from_moy method for DateTime and basic properties."""
+    dt1 = DateTime.from_moy(246960)
+    assert dt1 == DateTime(6, 21, 12)
+    dt2 = DateTime.from_moy(246960, leap_year=True)
+    assert dt2 == DateTime(6, 20, 12, leap_year=True)
+
+
+def test_date_time_add_sub():
+    """Test the add and subtract methods for DateTime."""
+    dt1 = DateTime(6, 21, 12)
+    dt2 = dt1.add_hour(1)
+    dt3 = dt1.sub_hour(1)
+    dt4 = dt1.add_minute(1)
+    dt5 = dt1.sub_minute(1)
+
+    assert dt2 == DateTime(6, 21, 13)
+    assert dt3 == DateTime(6, 21, 11)
+    assert dt4 == DateTime(6, 21, 12, 1)
+    assert dt5 == DateTime(6, 21, 11, 59)
+
+
+def test_date_init():
+    """Test the init method for Date and basic properties."""
+    dt1 = Date(6, 21)
+    dt2 = Date(6, 21)
+    dt3 = Date(6, 21, leap_year=True)
+    dt4 = Date(6, 22)
+    str(dt1)  # test the string representation of Date
+
+    assert dt1.month == 6
+    assert dt1.day == 21
+    assert not dt1.leap_year
+    assert dt1.doy == 172
+
+    assert dt1 == dt2
+    assert dt1 != dt3
+    assert dt1 != dt4
+
+    assert sorted([dt4, dt1]) == [dt1, dt4]
+
+
+def test_date_from_doy():
+    """Test the from_doy method for Date and basic properties."""
+    dt1 = Date.from_doy(172)
+    assert dt1 == Date(6, 21)
+    dt2 = Date.from_doy(172, leap_year=True)
+    assert dt2 == Date(6, 20, leap_year=True)
+
+
+def test_date_to_from_dict():
+    """Test the dict methods for Date."""
+    dt1 = Date(6, 21)
+    dt_dict = dt1.to_dict()
+    rebuilt_dt = Date.from_dict(dt_dict)
+    assert dt1 == rebuilt_dt
+    assert rebuilt_dt.to_dict() == dt_dict
+
+
+def test_to_from_date_string():
+    """Test the from_date_string method for Date."""
+    dt1 = Date(6, 21)
+    dt_str = str(dt1)
+    rebuilt_dt = Date.from_date_string(dt_str)
+    assert rebuilt_dt == dt1
+    assert str(rebuilt_dt) == dt_str
+
+
+def test_time_init():
+    """Test the init method for Date and basic properties."""
+    t1 = Time(12, 30)
+    t2 = Time(12, 30)
+    t3 = Time(12, 31)
+    str(t1)  # test the string representation of Time
+
+    assert t1.hour == 12
+    assert t1.minute == 30
+    assert t1.mod == 750
+
+    assert t1 == t2
+    assert t1 != t3
+
+    assert sorted([t3, t1]) == [t1, t3]
+
+
+def test_time_from_mod():
+    """Test the from_mod method for Time and basic properties."""
+    t1 = Time.from_mod(750)
+    assert t1 == Time(12, 30)
+
+
+def test_time_to_from_dict():
+    """Test the dict methods for Time."""
+    t1 = Time(12, 30)
+    t_dict = t1.to_dict()
+    rebuilt_t = Time.from_dict(t_dict)
+    assert t1 == rebuilt_t
+    assert rebuilt_t.to_dict() == t_dict
+
+
+def test_to_from_time_string():
+    """Test the from_time_string method for Time."""
+    t1 = Time(12, 30)
+    t_str = str(t1)
+    rebuilt_t = Time.from_time_string(t_str)
+    assert rebuilt_t == t1
+    assert str(rebuilt_t) == t_str


### PR DESCRIPTION
These two objects are particularly helpful for defining EnergyPlus schedules and there may be some other places where it is helpful to have these objects coordinated with the Ladybug DateTime and AnalysisPeriod as they are here.

This commit also adds a full set of tests for DateTime, Date, and Time.  It also includes a few corrections to places where we were internally using hasattr instead of isinstance.