### PR TITLE
feat(iterable): Update for compatibility with Python 3.8

### DIFF
--- a/ladybug/_datacollectionbase.py
+++ b/ladybug/_datacollectionbase.py
@@ -6,10 +6,12 @@ from __future__ import division
 from .header import Header
 from .datatype.base import DataTypeBase
 
-from collections import Iterable
+try:
+    from collections.abc import Iterable  # python < 3.7
+except ImportError:
+    from collections import Iterable  # python >= 3.8
 from string import ascii_lowercase
 import math
-
 import sys
 if (sys.version_info >= (3, 0)):
     xrange = range

--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -36,7 +36,10 @@ from .analysisperiod import AnalysisPeriod
 from .dt import DateTime
 
 from collections import OrderedDict
-from collections import Iterable
+try:
+    from collections.abc import Iterable  # python < 3.7
+except ImportError:
+    from collections import Iterable  # python >= 3.8
 try:
     from itertools import izip as zip  # python 2
 except ImportError:

--- a/ladybug/legend.py
+++ b/ladybug/legend.py
@@ -9,7 +9,10 @@ from ladybug_geometry.geometry3d.mesh import Mesh3D
 from ladybug_geometry.geometry2d.pointvector import Point2D
 from ladybug_geometry.geometry2d.mesh import Mesh2D
 
-from collections import Iterable
+try:
+    from collections.abc import Iterable  # python < 3.7
+except ImportError:
+    from collections import Iterable  # python >= 3.8
 import sys
 if (sys.version_info > (3, 0)):  # python 3
     xrange = range

--- a/ladybug/wea.py
+++ b/ladybug/wea.py
@@ -198,9 +198,9 @@ class Wea(object):
                                       epw.diffuse_horizontal_radiation.values,
                                       epw.metadata, 1, is_leap_year)
         if timestep != 1:
-            print ("Note: timesteps greater than 1 on epw-generated Wea's \n" +
-                   "are suitable for thermal models but are not recommended \n" +
-                   "for daylight models.")
+            print("Note: timesteps greater than 1 on epw-generated Wea's \n" +
+                  "are suitable for thermal models but are not recommended \n" +
+                  "for daylight models.")
             # interpolate the data
             direct_normal = direct_normal.interpolate_to_timestep(timestep)
             diffuse_horizontal = diffuse_horizontal.interpolate_to_timestep(timestep)


### PR DESCRIPTION
In Python 3.8, the option to import Iterable from collections will be deprecated in favor of `from collections.abc import Iterable`.  This commit brings ladybug into compatibility with this standard while also maintaining backwards compatibility.