### PR TITLE
Update several things in the formatting of the documentation #158

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,40 @@
+/*
+ * bootstrap-sphinx.css
+ * ~~~~~~~~~~~~~~~~~~~~
+ *
+ * Sphinx stylesheet -- Bootstrap theme.
+ */
+
+
+/* The code below is based on the bootstrap website sidebar */
+
+
+/* Show and affix the side nav when space allows it */
+@media screen and (min-width: 992px) {
+  .bs-sidenav .nav > .active > ul {
+    display: block;
+  }
+  /* Widen the fixed sidenav */
+  .bs-sidenav.affix,
+  .bs-sidenav.affix-bottom {
+    width: 292px;
+  }
+  .bs-sidenav.affix {
+    position: fixed; /* Undo the static from mobile first approach */
+  }
+  .bs-sidenav.affix-bottom {
+    position: absolute; /* Undo the static from mobile first approach */
+  }
+  .bs-sidenav.affix-bottom .bs-sidenav,
+  .bs-sidenav.affix .bs-sidenav {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}
+@media screen and (min-width: 1200px) {
+  /* Widen the fixed sidenav again */
+  .bs-sidenav.affix-bottom,
+  .bs-sidenav.affix {
+    width: 360px;
+  }
+}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,107 @@
+{% extends "basic/layout.html" %}
+
+{% if theme_bootstrap_version == "3" %}
+  {% set bootstrap_version, navbar_version = "3.3.7", "" %}
+  {% set bs_span_prefix = "col-md-" %}
+{% else %}
+  {% set bootstrap_version, navbar_version = "2.3.2", "-2" %}
+  {% set bs_span_prefix = "span" %}
+{% endif %}
+
+{%- set render_sidebar = (not embedded) and (not theme_nosidebar|tobool) and sidebars %}
+
+{%- set bs_content_width = render_sidebar and "8" or "12"%}
+
+{%- block doctype -%}
+<!DOCTYPE html>
+{%- endblock %}
+
+{# Sidebar: Rework into our Bootstrap nav section. #}
+{% macro navBar() %}
+{% include "navbar" + navbar_version + ".html" %}
+{% endmacro %}
+
+{% if theme_bootstrap_version == "3" %}
+  {%- macro bsidebar() %}
+      {%- if render_sidebar %}
+      <div class="{{ bs_span_prefix }}4">
+        <div id="sidebar" class="bs-sidenav" role="complementary">
+          {%- for sidebartemplate in sidebars %}
+            {%- include sidebartemplate %}
+          {%- endfor %}
+        </div>
+      </div>
+      {%- endif %}
+  {%- endmacro %}
+{% else %}
+  {%- macro bsidebar() %}
+      {%- if render_sidebar %}
+      <div class="{{ bs_span_prefix }}4">
+        <div id="sidebar" class="bs-sidenav well" data-spy="affix">
+          {%- for sidebartemplate in sidebars %}
+            {%- include sidebartemplate %}
+          {%- endfor %}
+        </div>
+      </div>
+      {%- endif %}
+  {%- endmacro %}
+{% endif %}
+
+{%- block extrahead %}
+<meta charset='utf-8'>
+<meta http-equiv='X-UA-Compatible' content='IE=edge,chrome=1'>
+<meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1'>
+<meta name="apple-mobile-web-app-capable" content="yes">
+<script type="text/javascript" src="{{ pathto('_static/js/jquery-1.11.0.min.js', 1) }} "></script>
+<script type="text/javascript" src="{{ pathto('_static/js/jquery-fix.js', 1) }} "></script>
+<script type="text/javascript" src="{{ pathto('_static', 1) + '/bootstrap-' + bootstrap_version + '/js/bootstrap.min.js' }} "></script>
+<script type="text/javascript" src="{{ pathto('_static/bootstrap-sphinx.js', 1) }} "></script>
+{% endblock %}
+
+{# Silence the sidebar's, relbar's #}
+{% block header %}{% endblock %}
+{% block relbar1 %}{% endblock %}
+{% block relbar2 %}{% endblock %}
+{% block sidebarsourcelink %}{% endblock %}
+
+{%- block content %}
+{{ navBar() }}
+<div class="container">
+  <div class="row">
+    {%- block sidebar1 %}{{ bsidebar() }}{% endblock %}
+    <div class="body {{ bs_span_prefix }}{{ bs_content_width }} content" role="main">
+      {% block body %}{% endblock %}
+    </div>
+    {% block sidebar2 %} {# possible location for sidebar #} {% endblock %}
+  </div>
+</div>
+{%- endblock %}
+
+{%- block footer %}
+<footer class="footer">
+  <div class="container">
+    <p class="pull-right">
+      <a href="#">Back to top</a>
+      {% if theme_source_link_position == "footer" %}
+        <br/>
+        {% include "sourcelink.html" %}
+      {% endif %}
+    </p>
+    <p>
+    {%- if show_copyright %}
+      {%- if hasdoc('copyright') %}
+        {% trans path=pathto('copyright'), copyright=copyright|e %}&copy; <a href="{{ path }}">Copyright</a> {{ copyright }}.{% endtrans %}<br/>
+      {%- else %}
+        {% trans copyright=copyright|e %}&copy; Copyright {{ copyright }}.{% endtrans %}<br/>
+      {%- endif %}
+    {%- endif %}
+    {%- if last_updated %}
+      {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}<br/>
+    {%- endif %}
+    {%- if show_sphinx %}
+      {% trans sphinx_version=sphinx_version|e %}Created using <a href="http://sphinx-doc.org/">Sphinx</a> {{ sphinx_version }}.{% endtrans %}<br/>
+    {%- endif %}
+    </p>
+  </div>
+</footer>
+{%- endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -223,7 +223,7 @@ autodoc_member_order = 'groupwise'
 
 
 def setup(app):
-    """Run custom code with access to the Shinx application object
+    """Run custom code with access to the Sphinx application object
 
     Args:
         app: the Sphinx application object

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,8 +6,6 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/master/config
 
-import re
-
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -224,110 +224,12 @@ autodoc_default_options = {
 autodoc_member_order = 'groupwise'
 
 
-# Autodoc event handlers
-def autodoc_process_docstring(app, what, name, obj, options, lines):
-    """Function to handle the autodoc-process-docstring event.
-
-    Emitted when autodoc has read and processed a docstring. lines is a list of
-    strings – the lines of the processed docstring – that the event handler
-    can modify in place to change what Sphinx puts into the output.
-
-    More information on sphinx documentation:
-        http://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
-        #event-autodoc-process-docstring
-
-    Args:
-        app: the Sphinx application object
-        what: the type of the object which the docstring belongs to (one of "module",
-            "class", "exception", "function", "method", "attribute")
-        name: the fully qualified name of the object
-        obj: the object itself
-        options: the options given to the directive: an object with attributes
-            inherited_members, undoc_members, show_inheritance and noindex that
-            are true if the flag option of same name was given to the auto directive
-        lines: the lines of the docstring
-    """
-
-    # Make class properties display matching the 'Args' format
-    if what == 'class':
-        make_properties_one_liner(lines)
-        make_fields_bolded(lines)
-
-    return lines
-
-
-def make_properties_one_liner(lines):
-    """Ensures that lines with the 'field: value' format that extend multiple
-    lines are merged into a single line. The multiline properties display secondary
-    lines incorrectly when field is made bolded.
-
-    Args:
-        lines: the lines of the docstring
-    """
-
-    # Connect the list strings into a single string
-    doc_text = "\n".join(lines) + "\n"
-
-    # Generate groups based on three possible line formats:
-    # 1: new line (\n)
-    # 2: Bulleted field: value (?:(\s*\*\s*)(\w+)(\s*:)([^\n]+)\n)
-    # 3: Any other string: (?:(\s*)([^\n]+)\n)
-    matches = re.findall(
-        r"(\n)|(?:(\s*\*\s*)(\w+)(\s*:)([^\n]+)\n)|(?:(\s*)([^\n]+)\n)", doc_text)
-
-    # Traverse groups to detect and join multilined field:value cases
-    i, field_i = 0, -1
-    while i < len(matches):
-        group = matches[i]
-        # Check for bulleted field:value line and track line index
-        if "*" in group[1]:
-            field_i = i
-        # Check if it is next line of field:value line(not bulleted & text vertically
-        # aligned)
-        # Connect this line's text group to parent field:value line
-        elif group[6] != '' and field_i >= 0 and group[6].lstrip()[0] != "*" and \
-                len(group[5]) == len(matches[field_i][1]):
-            lines[field_i] = lines[field_i] + ' ' + group[6]
-            lines[i] = ""
-        # If not aligned text line or empty line reset field:value line index
-        else:
-            field_i = -1
-        # Loop through every line match
-        i += 1
-
-
-def make_fields_bolded(lines):
-    """Make field font bolded in 'field: value' line format.
-
-    Note the purpose of this change is to match the class 'Parameters'
-    and 'Args' fields format.
-    Regex pattern "(\s*\*\s*)(\w+)(\s*:)(.+)" detects range of 'field: value'
-    formats.
-
-    Args:
-        lines: the lines of the docstring
-    """
-
-    # Include boldface (reST inline markup '**') in field names of matching lines
-    def replace(match):
-        return "{0[0]} **{0[1]}** --{0[3]}".format(match.groups())
-
-    # Substitute macthing lines
-    new_lines = [re.sub(r"(\s*\*\s*)(\w+)(\s*:)(.+)", replace, line) for line in lines]
-
-    # Copy changes back to lines (in place)
-    for i in range(len(lines)):
-        lines[i] = new_lines[i]
-
-
 def setup(app):
     """Run custom code with access to the Shinx application object
 
     Args:
         app: the Sphinx application object
     """
-    # Register the event handler for 'autodoc-process-docstring' event
-    app.connect('autodoc-process-docstring', autodoc_process_docstring)
 
     # Add bootstrap theme custom stylesheet
     app.add_stylesheet("custom.css")

--- a/ladybug/_datacollectionbase.py
+++ b/ladybug/_datacollectionbase.py
@@ -18,7 +18,14 @@ if (sys.version_info >= (3, 0)):
 
 
 class BaseCollection(object):
-    """Base class for all Data Collections."""
+    """Base class for all Data Collections.
+
+    Args:
+        header: A Ladybug Header object.
+        values: A list of values.
+        datetimes: A list of Ladybug DateTime objects that aligns with
+            the list of values.
+    """
 
     __slots__ = ('_header', '_values', '_datetimes', '_validated_a_period')
     _collection_type = None
@@ -27,12 +34,6 @@ class BaseCollection(object):
 
     def __init__(self, header, values, datetimes):
         """Initialize base collection.
-
-        Args:
-            header: A Ladybug Header object.
-            values: A list of values.
-            datetimes: A list of Ladybug DateTime objects that aligns with
-                the list of values.
         """
         assert isinstance(header, Header), \
             'header must be a Ladybug Header object. Got {}'.format(type(header))
@@ -50,11 +51,15 @@ class BaseCollection(object):
         """Create a Data Collection from a dictionary.
 
         Args:
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
             {
-                "header": A Ladybug Header,
-                "values": An array of values,
-                "datetimes": An array of datetimes,
-                "validated_a_period": Boolean for whether header analysis_period is valid
+            "header": A Ladybug Header,
+            "values": An array of values,
+            "datetimes": An array of datetimes,
+            "validated_a_period": Boolean for whether header analysis_period is valid
             }
         """
         assert 'header' in data, 'Required keyword "header" is missing!'
@@ -189,9 +194,14 @@ class BaseCollection(object):
             count: Integer representing the number of highest values to account for.
 
         Returns:
-            highest_values: The n highest values in data list, ordered from
+            A tuple with two elements.
+
+            -   highest_values:
+                The n highest values in data list, ordered from
                 highest to lowest.
-            highest_values_index: Indicies of the n highest values in data
+
+            -   highest_values_index:
+                Indicies of the n highest values in data
                 list, ordered from highest to lowest.
         """
         count = int(count)
@@ -216,9 +226,13 @@ class BaseCollection(object):
             count: Integer representing the number of lowest values to account for.
 
         Returns:
-            highest_values: The n lowest values in data list, ordered from
+            A tuple with two elements.
+
+            -   highest_values:
+                The n lowest values in data list, ordered from
                 lowest to lowest.
-            lowest_values_index: Indicies of the n lowest values in data
+            -   lowest_values_index:
+                Indicies of the n lowest values in data
                 list, ordered from lowest to lowest.
         """
         count = int(count)
@@ -375,8 +389,8 @@ class BaseCollection(object):
                 The variable should always be named as 'a' (without quotations).
 
         Return:
-            collections: A list of Data Collections that have been filtered based
-                on the statement.
+            collections -- A list of Data Collections that have been filtered based
+            on the statement.
         """
         pattern = BaseCollection.pattern_from_collections_and_statement(
             data_collections, statement)
@@ -398,9 +412,9 @@ class BaseCollection(object):
                 The variable should always be named as 'a' (without quotations).
 
         Return:
-            pattern: A list of True/False booleans with the length of the
-                Data Collections where True meets the conditional statement
-                and False does not.
+            pattern -- A list of True/False booleans with the length of the
+            Data Collections where True meets the conditional statement
+            and False does not.
         """
         BaseCollection.are_collections_aligned(data_collections)
         correct_var = BaseCollection._check_conditional_statement(
@@ -467,6 +481,9 @@ class BaseCollection(object):
             data_collections are individual values, only a single value will be returned.
 
         Usage:
+
+        .. code-block:: shell
+
             from ladybug.datacollection import HourlyContinuousCollection
             from ladybug.epw import EPW
             from ladybug.psychrometrics import humid_ratio_from_db_rh
@@ -518,7 +535,7 @@ class BaseCollection(object):
                 that the statement will be evaluating.
 
         Return:
-            correct_var: A list of the correct variable names that should be
+            correct_var -- A list of the correct variable names that should be
                 used within the statement (eg. ['a', 'b', 'c'])
         """
         # Determine what the list of variables should be based on the num_collections

--- a/ladybug/_datacollectionbase.py
+++ b/ladybug/_datacollectionbase.py
@@ -56,11 +56,11 @@ class BaseCollection(object):
         .. code-block:: python
 
             {
-            "header": h  # A Ladybug Header,
-            "values": v  # An array of values,
-            "datetimes": d  # An array of datetimes,
-            "validated_a_period": p  # Boolean for whether header
-                                     #analysis_period is valid
+            "header": {},  # A Ladybug Header
+            "values": [],  # An array of values
+            "datetimes": [],  # An array of datetimes
+            "validated_a_period": True  # Boolean for whether header analysis_period
+                                        # is valid
             }
         """
         assert 'header' in data, 'Required keyword "header" is missing!'

--- a/ladybug/_datacollectionbase.py
+++ b/ladybug/_datacollectionbase.py
@@ -53,13 +53,14 @@ class BaseCollection(object):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
             {
-            "header": A Ladybug Header,
-            "values": An array of values,
-            "datetimes": An array of datetimes,
-            "validated_a_period": Boolean for whether header analysis_period is valid
+            "header": h  # A Ladybug Header,
+            "values": v  # An array of values,
+            "datetimes": d  # An array of datetimes,
+            "validated_a_period": p  # Boolean for whether header
+                                     #analysis_period is valid
             }
         """
         assert 'header' in data, 'Required keyword "header" is missing!'
@@ -482,7 +483,7 @@ class BaseCollection(object):
 
         Usage:
 
-        .. code-block:: shell
+        .. code-block:: python
 
             from ladybug.datacollection import HourlyContinuousCollection
             from ladybug.epw import EPW

--- a/ladybug/analysisperiod.py
+++ b/ladybug/analysisperiod.py
@@ -28,10 +28,6 @@ class AnalysisPeriod(object):
         is_leap_year: A boolean to indicate whether the AnalysisPeriod represents
             a leap year.
 
-    Class methods:
-        * from_string: Create an Analysis Period object from an analysis period string.
-          %s/%s to %s/%s between %s to %s @%s
-
     Properties:
         * st_time
         * end_time

--- a/ladybug/analysisperiod.py
+++ b/ladybug/analysisperiod.py
@@ -33,27 +33,19 @@ class AnalysisPeriod(object):
           %s/%s to %s/%s between %s to %s @%s
 
     Properties:
-        * st_time: A DateTime object representing the start time.
-        * end_time: A DateTime object representing the end time.
-        * datetimes: A sorted list of DateTimes in this analysis period.
-        * moys: A sorted list of minutes of year in this analysis period
-          as integers.
-        * hoys: A sorted list of hours of year in this analysis period as floats.
-        * hoys_int: A sorted list of hours of year values in this analysis period
-          as integers.
-        * doys_int: A sorted list of days of the year in this analysis period
-          as integers.
-        * months_int: A sorted list of months of the year in this analysis period
-          as integers.
-        * months_per_hour_str: A list of strings representing hours per month
-          in this analysis period
-        * minute_intervals: The number of minutes between each of the timesteps
-          of the analysis period
-        * is_annual: Check if the analysis period is annual.
-        * is_overnight: If an analysis period is not overnight each segments of hours
-          will be in the same day (self.st_time.hoy < self.end_time.hoy)
-        * is_reversed: A reversed analysis period defines a period that starting month
-          is after ending month (e.g DEC to JUN).
+        * st_time
+        * end_time
+        * datetimes
+        * moys
+        * hoys
+        * hoys_int
+        * doys_int
+        * months_int
+        * months_per_hour_str
+        * minute_intervals
+        * is_annual
+        * is_overnight
+        * is_reversed
     """
 
     VALIDTIMESTEPS = {1: 60, 2: 30, 3: 20, 4: 15, 5: 12,
@@ -122,38 +114,19 @@ class AnalysisPeriod(object):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
-                {
-                "st_month": 1,
-                "st_day": 1,
-                "st_hour": 0,
-                "end_month": 12,
-                "end_day": 31,
-                "end_hour": 23,
-                "timestep": 1
-                }
-
-
-        Data keys:
-            *   st_month: An integer between 1-12 for starting month (default = 1)
-            *   st_day: An integer between 1-31 for starting day (default = 1).
-                Note that some months are shorter than 31 days.
-            *   st_hour: An integer between 0-23 for starting hour (default = 0)
-            *   end_month: An integer between 1-12 for ending month (default = 12)
-            *   end_day:    An integer between 1-31 for ending day (default = 31)
-                Note that some months are shorter than 31 days.
-            *   end_hour: An integer between 0-23 for ending hour (default = 23)
-            *   timestep: An integer number from 1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60
-            *   st_month: An integer between 1-12 for starting month (default = 1)
-            *   st_day: An integer between 1-31 for starting day (default = 1).
-                Note that some months are shorter than 31 days.'
-            *   st_hour: An integer between 0-23 for starting hour (default = 0)
-            *   end_month: An integer between 1-12 for ending month (default = 12)
-            *   end_day:    An integer between 1-31 for ending day (default = 31)
-                Note that some months are shorter than 31 days.
-            *   end_hour: An integer between 0-23 for ending hour (default = 23)
-            *   timestep: An integer number from 1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60
+            {
+            st_month: 1  # An integer between 1-12 for starting month (default = 1)
+            st_day: 1  # An integer between 1-31 for starting day (default = 1).
+                       # Note that some months are shorter than 31 days.
+            st_hour: 0  # An integer between 0-23 for starting hour (default = 0)
+            end_month: 12  # An integer between 1-12 for ending month (default = 12)
+            end_day: 31  # An integer between 1-31 for ending day (default = 31)
+                         #Note that some months are shorter than 31 days.
+            end_hour: 23  # An integer between 0-23 for ending hour (default = 23)
+            timestep: 1 # An integer number from 1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60
+            }
         """
         keys = ('st_month', 'st_day', 'st_hour', 'end_month',
                 'end_day', 'end_hour', 'timestep', 'is_leap_year')

--- a/ladybug/analysisperiod.py
+++ b/ladybug/analysisperiod.py
@@ -15,7 +15,7 @@ class AnalysisPeriod(object):
 
     A continuous analysis period between two days of the year between certain hours.
 
-    Attributes:
+    Args:
         st_month: An integer between 1-12 for starting month (default = 1)
         st_day: An integer between 1-31 for starting day (default = 1).
                 Note that some months are shorter than 31 days.
@@ -29,31 +29,31 @@ class AnalysisPeriod(object):
             a leap year.
 
     Class methods:
-        from_string: Create an Analysis Period object from an analysis period string.
-            %s/%s to %s/%s between %s to %s @%s
+        * from_string: Create an Analysis Period object from an analysis period string.
+          %s/%s to %s/%s between %s to %s @%s
 
     Properties:
-        st_time: A DateTime object representing the start time.
-        end_time: A DateTime object representing the end time.
-        datetimes: A sorted list of DateTimes in this analysis period.
-        moys: A sorted list of minutes of year in this analysis period
-            as integers.
-        hoys: A sorted list of hours of year in this analysis period as floats.
-        hoys_int: A sorted list of hours of year values in this analysis period
-            as integers.
-        doys_int: A sorted list of days of the year in this analysis period
-            as integers.
-        months_int: A sorted list of months of the year in this analysis period
-            as integers.
-        months_per_hour_str: A list of strings representing hours per month
-            in this analysis period
-        minute_intervals: The number of minutes between each of the timesteps
-            of the analysis period
-        is_annual: Check if the analysis period is annual.
-        is_overnight: If an analysis period is not overnight each segments of hours
-            will be in the same day (self.st_time.hoy < self.end_time.hoy)
-        is_reversed: A reversed analysis period defines a period that starting month
-            is after ending month (e.g DEC to JUN)
+        * st_time: A DateTime object representing the start time.
+        * end_time: A DateTime object representing the end time.
+        * datetimes: A sorted list of DateTimes in this analysis period.
+        * moys: A sorted list of minutes of year in this analysis period
+          as integers.
+        * hoys: A sorted list of hours of year in this analysis period as floats.
+        * hoys_int: A sorted list of hours of year values in this analysis period
+          as integers.
+        * doys_int: A sorted list of days of the year in this analysis period
+          as integers.
+        * months_int: A sorted list of months of the year in this analysis period
+          as integers.
+        * months_per_hour_str: A list of strings representing hours per month
+          in this analysis period
+        * minute_intervals: The number of minutes between each of the timesteps
+          of the analysis period
+        * is_annual: Check if the analysis period is annual.
+        * is_overnight: If an analysis period is not overnight each segments of hours
+          will be in the same day (self.st_time.hoy < self.end_time.hoy)
+        * is_reversed: A reversed analysis period defines a period that starting month
+          is after ending month (e.g DEC to JUN).
     """
 
     VALIDTIMESTEPS = {1: 60, 2: 30, 3: 20, 4: 15, 5: 12,
@@ -67,21 +67,6 @@ class AnalysisPeriod(object):
     def __init__(self, st_month=1, st_day=1, st_hour=0, end_month=12,
                  end_day=31, end_hour=23, timestep=1, is_leap_year=False):
         """Init an analysis period.
-
-        A continuous analysis period between two days of the year between certain hours
-
-        Args:
-            st_month: An integer between 1-12 for starting month (default = 1)
-            st_day: An integer between 1-31 for starting day (default = 1).
-                    Note that some months are shorter than 31 days.
-            st_hour: An integer between 0-23 for starting hour (default = 0)
-            end_month: An integer between 1-12 for ending month (default = 12)
-            end_day: An integer between 1-31 for ending day (default = 31)
-                    Note that some months are shorter than 31 days.
-            end_hour: An integer between 0-23 for ending hour (default = 23)
-            timestep: An integer number from 1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60
-            is_leap_year: A boolean to note whether the Analysis Period
-                represents a leap year.
         """
 
         st_month = st_month or 1
@@ -133,18 +118,42 @@ class AnalysisPeriod(object):
     @classmethod
     def from_dict(cls, data):
         """Create an analysis period from a dictionary.
+
         Args:
-            data: {
-            st_month: An integer between 1-12 for starting month (default = 1)
-            st_day: An integer between 1-31 for starting day (default = 1).
-                    Note that some months are shorter than 31 days.
-            st_hour: An integer between 0-23 for starting hour (default = 0)
-            end_month: An integer between 1-12 for ending month (default = 12)
-            end_day: An integer between 1-31 for ending day (default = 31)
-                    Note that some months are shorter than 31 days.
-            end_hour: An integer between 0-23 for ending hour (default = 23)
-            timestep: An integer number from 1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60
-            }
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+                {
+                "st_month": 1,
+                "st_day": 1,
+                "st_hour": 0,
+                "end_month": 12,
+                "end_day": 31,
+                "end_hour": 23,
+                "timestep": 1
+                }
+
+
+        Data keys:
+            *   st_month: An integer between 1-12 for starting month (default = 1)
+            *   st_day: An integer between 1-31 for starting day (default = 1).
+                Note that some months are shorter than 31 days.
+            *   st_hour: An integer between 0-23 for starting hour (default = 0)
+            *   end_month: An integer between 1-12 for ending month (default = 12)
+            *   end_day:    An integer between 1-31 for ending day (default = 31)
+                Note that some months are shorter than 31 days.
+            *   end_hour: An integer between 0-23 for ending hour (default = 23)
+            *   timestep: An integer number from 1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60
+            *   st_month: An integer between 1-12 for starting month (default = 1)
+            *   st_day: An integer between 1-31 for starting day (default = 1).
+                Note that some months are shorter than 31 days.'
+            *   st_hour: An integer between 0-23 for starting hour (default = 0)
+            *   end_month: An integer between 1-12 for ending month (default = 12)
+            *   end_day:    An integer between 1-31 for ending day (default = 31)
+                Note that some months are shorter than 31 days.
+            *   end_hour: An integer between 0-23 for ending hour (default = 23)
+            *   timestep: An integer number from 1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60
         """
         keys = ('st_month', 'st_day', 'st_hour', 'end_month',
                 'end_day', 'end_hour', 'timestep', 'is_leap_year')

--- a/ladybug/analysisperiod.py
+++ b/ladybug/analysisperiod.py
@@ -117,15 +117,16 @@ class AnalysisPeriod(object):
         .. code-block:: python
 
             {
-            st_month: 1  # An integer between 1-12 for starting month (default = 1)
-            st_day: 1  # An integer between 1-31 for starting day (default = 1).
+            "st_month": 1  # An integer between 1-12 for starting month (default = 1)
+            "st_day": 1  # An integer between 1-31 for starting day (default = 1).
                        # Note that some months are shorter than 31 days.
-            st_hour: 0  # An integer between 0-23 for starting hour (default = 0)
-            end_month: 12  # An integer between 1-12 for ending month (default = 12)
-            end_day: 31  # An integer between 1-31 for ending day (default = 31)
+            "st_hour": 0  # An integer between 0-23 for starting hour (default = 0)
+            "end_month": 12  # An integer between 1-12 for ending month (default = 12)
+            "end_day": 31  # An integer between 1-31 for ending day (default = 31)
                          #Note that some months are shorter than 31 days.
-            end_hour: 23  # An integer between 0-23 for ending hour (default = 23)
-            timestep: 1 # An integer number from 1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60
+            "end_hour": 23  # An integer between 0-23 for ending hour (default = 23)
+            "timestep": 1 # An integer number from 1, 2, 3, 4, 5, 6, 10, 12, 15,
+                          #20, 30, 60
             }
         """
         keys = ('st_month', 'st_day', 'st_hour', 'end_month',

--- a/ladybug/color.py
+++ b/ladybug/color.py
@@ -8,7 +8,7 @@ from collections import Iterable
 class Color(object):
     """Ladybug RGB color.
 
-    Attributes:
+    Args:
         r: red value 0-255, default: 0
         g: green value 0-255, default: 0
         b: blue red value 0-255, default: 0
@@ -18,11 +18,6 @@ class Color(object):
 
     def __init__(self, r, g, b):
         """Generate RGB Color.
-
-        Args:
-            r: red value 0-255, default: 0
-            g: green value 0-255, default: 0
-            b: blue red value 0-255, default: 0
         """
         self.r = r
         self.g = g
@@ -33,10 +28,15 @@ class Color(object):
         """Create a color from a dictionary.
 
         Args:
-            data: {
-            "r": 255,
-            "g": 0,
-            "b": 150}
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+                {
+                "r": 255,
+                "g": 0,
+                "b": 150
+                }
         """
         return cls(data['r'], data['g'], data['b'])
 
@@ -121,38 +121,40 @@ class Colorset(object):
     """Ladybug Color-range repository.
 
     A list of default Ladybug colorsets for color range:
-        0 - original Ladybug
-        1 - nuanced Ladybug
-        2 - Multi-colored Ladybug
-        3 - View Analysis 1
-        4 - View Analysis 2 (Red,Green,Blue)
-        5 - Sunlight Hours
-        6 - ecotect
-        7 - thermal Comfort Percentage
-        8 - thermal Comfort Colors
-        9 - thermal Comfort Colors (UTCI)
-        10 - Hot Hours
-        11 - Cold Hours
-        12 - Shade Benefit/Harm
-        13 - thermal Comfort Colors v2 (UTCI)
-        14 - Shade Harm
-        15 - Shade Benefit
-        16 - Black to White
-        17 - CFD Colors 1
-        18 - CFD Colors 2
-        19 - Energy Balance
-        20 - THERM
-        21 - Cloud Cover
+        * 0 - original Ladybug
+        * 1 - nuanced Ladybug
+        * 2 - Multi-colored Ladybug
+        * 3 - View Analysis 1
+        * 4 - View Analysis 2 (Red,Green,Blue)
+        * 5 - Sunlight Hours
+        * 6 - ecotect
+        * 7 - thermal Comfort Percentage
+        * 8 - thermal Comfort Colors
+        * 9 - thermal Comfort Colors (UTCI)
+        * 10 - Hot Hours
+        * 11 - Cold Hours
+        * 12 - Shade Benefit/Harm
+        * 13 - thermal Comfort Colors v2 (UTCI)
+        * 14 - Shade Harm
+        * 15 - Shade Benefit
+        * 16 - Black to White
+        * 17 - CFD Colors 1
+        * 18 - CFD Colors 2
+        * 19 - Energy Balance
+        * 20 - THERM
+        * 21 - Cloud Cover
 
     Usage:
 
+    .. code-block:: shell
+
         # initiare colorsets
-        cs = Colorset()
-        print(cs[0])
-        >> [<R:75, G:107, B:169>, <R:115, G:147, B:202>, <R:170, G:200, B:247>,
-            <R:193, G:213, B:208>, <R:245, G:239, B:103>, <R:252, G:230, B:74>,
-            <R:239, G:156, B:21>, <R:234, G:123, B:0>, <R:234, G:74, B:0>,
-            <R:234, G:38, B:0>]
+            cs = Colorset()
+            print(cs[0])
+            >> [<R:75, G:107, B:169>, <R:115, G:147, B:202>, <R:170, G:200, B:247>,
+                <R:193, G:213, B:208>, <R:245, G:239, B:103>, <R:252, G:230, B:74>,
+                <R:239, G:156, B:21>, <R:234, G:123, B:0>, <R:234, G:74, B:0>,
+                <R:234, G:38, B:0>]
     """
     # base color sets for which there are several variations
     _multicolored = [(4, 25, 145), (7, 48, 224), (7, 88, 255), (1, 232, 255),
@@ -366,27 +368,30 @@ class ColorRange(object):
     """Ladybug Color Range. Used to generate colors from numerical values.
 
     Usage:
-        ##
-        color_range = ColorRange(continuous_colors=False)
-        color_range.domain = [100, 2000]
-        color_range.colors = [Color(75, 107, 169), Color(245, 239, 103),
-            Color(234, 38, 0)]
-        print(color_range.color(99))
-        print(color_range.color(100))
-        print(color_range.color(2000))
-        print(color_range.color(2001))
-        >> (R:75, G:107, B:169)
-        >> (R:245, G:239, B:103)
-        >> (R:245, G:239, B:103)
-        >> (R:234, G:38, B:0)
 
-        ##
-        color_range = ColorRange(continuous_colors=False)
-        color_range.domain = [100, 2000]
-        color_range.colors = [Color(75, 107, 169), Color(245, 239, 103),
-            Color(234, 38, 0)]
-        color_range.color(300)
-        >> (R:245, G:239, B:103)
+    .. code-block:: shell
+
+        1.
+            color_range = ColorRange(continuous_colors=False)
+            color_range.domain = [100, 2000]
+            color_range.colors = [Color(75, 107, 169), Color(245, 239, 103),
+                Color(234, 38, 0)]
+            print(color_range.color(99))
+            print(color_range.color(100))
+            print(color_range.color(2000))
+            print(color_range.color(2001))
+            >> (R:75, G:107, B:169)
+            >> (R:245, G:239, B:103)
+            >> (R:245, G:239, B:103)
+            >> (R:234, G:38, B:0)
+
+        2.
+            color_range = ColorRange(continuous_colors=False)
+            color_range.domain = [100, 2000]
+            color_range.colors = [Color(75, 107, 169), Color(245, 239, 103),
+                Color(234, 38, 0)]
+            color_range.color(300)
+            >> (R:245, G:239, B:103)
     """
 
     def __init__(self, colors=None, domain=None, continuous_colors=None):
@@ -421,10 +426,15 @@ class ColorRange(object):
         """Create a color range from a dictionary.
 
         Args:
-            data: {
-            "colors": ({'r': 0, 'g': 0, 'b': 0}, {'r': 255, 'g': 255, 'b': 255}),
-            "domain": (0, 100),
-            "continuous_colors": True}
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+            {
+            "colors": [{'r': 0, 'g': 0, 'b': 0}, {'r': 255, 'g': 255, 'b': 255}],
+            "domain": [0, 100],
+            "continuous_colors": True
+            }
         """
         optional_keys = ('colors', 'domain', 'continuous_colors')
         for key in optional_keys:

--- a/ladybug/color.py
+++ b/ladybug/color.py
@@ -373,7 +373,6 @@ class ColorRange(object):
     """Ladybug Color Range. Used to generate colors from numerical values.
 
     Args:
-        range:
         colors: A list of colors. Colors should be input as objects with
             R, G, B values. Default is Ladybug's original colorset.
         domain: A list of at least two numbers to set the lower and upper

--- a/ladybug/color.py
+++ b/ladybug/color.py
@@ -12,6 +12,11 @@ class Color(object):
         r: red value 0-255, default: 0
         g: green value 0-255, default: 0
         b: blue red value 0-255, default: 0
+
+    Properties:
+        * r
+        * g
+        * b
     """
 
     __slots__ = ("_r", "_g", "_b")
@@ -30,7 +35,7 @@ class Color(object):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
                 {
                 "r": 255,
@@ -146,7 +151,7 @@ class Colorset(object):
 
     Usage:
 
-    .. code-block:: shell
+    .. code-block:: python
 
         # initiare colorsets
             cs = Colorset()
@@ -367,9 +372,29 @@ class Colorset(object):
 class ColorRange(object):
     """Ladybug Color Range. Used to generate colors from numerical values.
 
+    Args:
+        range:
+        colors: A list of colors. Colors should be input as objects with
+            R, G, B values. Default is Ladybug's original colorset.
+        domain: A list of at least two numbers to set the lower and upper
+            boundary of the color range. This can also be a list of more than
+            two values, which can be used to approximate logartihmic or other types
+            of color scales. However, the number of values in the domain must
+            always be less than or equal to the number of colors.
+            Default: [0, 1].
+        continuous_colors: Boolean. If True, the colors generated from the
+            color range will be in a continuous gradient. If False,
+            they will be categorized in incremental groups according to the
+            number_of_segments. Default is True for continuous colors.
+
+    Properties:
+        * colors
+        * continuous_colors
+        * domain
+
     Usage:
 
-    .. code-block:: shell
+    .. code-block:: python
 
         1.
             color_range = ColorRange(continuous_colors=False)
@@ -396,21 +421,6 @@ class ColorRange(object):
 
     def __init__(self, colors=None, domain=None, continuous_colors=None):
         """Initiate Ladybug color range.
-
-        Args:
-            range:
-            colors: A list of colors. Colors should be input as objects with
-                R, G, B values. Default is Ladybug's original colorset.
-            domain: A list of at least two numbers to set the lower and upper
-                boundary of the color range. This can also be a list of more than
-                two values, which can be used to approximate logartihmic or other types
-                of color scales. However, the number of values in the domain must
-                always be less than or equal to the number of colors.
-                Default: [0, 1].
-            continuous_colors: Boolean. If True, the colors generated from the
-                color range will be in a continuous gradient. If False,
-                they will be categorized in incremental groups according to the
-                number_of_segments. Default is True for continuous colors.
         """
         self._continuous_colors = True if continuous_colors is None \
             else continuous_colors
@@ -428,7 +438,7 @@ class ColorRange(object):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
             {
             "colors": [{'r': 0, 'g': 0, 'b': 0}, {'r': 255, 'g': 255, 'b': 255}],

--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -105,11 +105,11 @@ class HourlyDiscontinuousCollection(BaseCollection):
         .. code-block:: python
 
                 {
-                "header": h  # A Ladybug Header,
-                "values": v  # An array of values,
-                "datetimes": d  # An array of datetimes,
-                "validated_a_period": p  # Boolean for whether header
-                                          # analysis_period is valid
+                "header": {}  # A Ladybug Header,
+                "values": []  # An array of values,
+                "datetimes": []  # An array of datetimes,
+                "validated_a_period": True  # Boolean for whether header
+                                            # analysis_period is valid
                 }
         """
         assert 'header' in data, 'Required keyword "header" is missing!'
@@ -603,8 +603,8 @@ class HourlyContinuousCollection(HourlyDiscontinuousCollection):
         .. code-block:: python
 
                 {
-                "header": h  # A Ladybug Header,
-                "values": v  # An array of values,
+                "header": {}  # A Ladybug Header,
+                "values": []  # An array of values,
                 }
         """
         assert 'header' in data, 'Required keyword "header" is missing!'

--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -63,8 +63,6 @@ class HourlyDiscontinuousCollection(BaseCollection):
         * bounds
         * datetimes
         * header
-        * isDataCollection
-        * isHourly
         * is_continuous
         * is_mutable
         * max
@@ -543,7 +541,7 @@ class HourlyDiscontinuousCollection(BaseCollection):
 
 
 class HourlyContinuousCollection(HourlyDiscontinuousCollection):
-    """Class for Continouus Data Collections at hourly or sub-hourly intervals.
+    """Class for Continuous Data Collections at hourly or sub-hourly intervals.
 
     Args:
         header: A Ladybug Header object.  Note that this header
@@ -558,8 +556,6 @@ class HourlyContinuousCollection(HourlyDiscontinuousCollection):
         * datetimes
         * header
         * isContinuous
-        * isDataCollection
-        * isHourly
         * is_continuous
         * is_mutable
         * max
@@ -1008,9 +1004,6 @@ class DailyCollection(BaseCollection):
         * bounds
         * datetimes
         * header
-        * isDataCollection
-        * isMonthlyPerHour
-        * isHourly
         * is_continuous
         * is_mutable
         * max
@@ -1242,9 +1235,6 @@ class MonthlyCollection(BaseCollection):
         * bounds
         * datetimes
         * header
-        * isDataCollection
-        * isMonthlyPerHour
-        * isHourly
         * is_continuous
         * is_mutable
         * max
@@ -1395,9 +1385,6 @@ class MonthlyPerHourCollection(BaseCollection):
         * bounds
         * datetimes
         * header
-        * isDataCollection
-        * isMonthlyPerHour
-        * isHourly
         * is_continuous
         * is_mutable
         * max

--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -102,13 +102,14 @@ class HourlyDiscontinuousCollection(BaseCollection):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
                 {
-                "header": A Ladybug Header,
-                "values": An array of values,
-                "datetimes": An array of datetimes,
-                "validated_a_period": Boolean for whether header analysis_period is valid
+                "header": h  # A Ladybug Header,
+                "values": v  # An array of values,
+                "datetimes": d  # An array of datetimes,
+                "validated_a_period": p  # Boolean for whether header
+                                          # analysis_period is valid
                 }
         """
         assert 'header' in data, 'Required keyword "header" is missing!'
@@ -599,11 +600,11 @@ class HourlyContinuousCollection(HourlyDiscontinuousCollection):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
                 {
-                "header": A Ladybug Header,
-                "values": An array of values,
+                "header": h  # A Ladybug Header,
+                "values": v  # An array of values,
                 }
         """
         assert 'header' in data, 'Required keyword "header" is missing!'

--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -16,10 +16,10 @@ Collections have the following inheritence structure:
 
 
 All Data Collections in this module have the ability to:
-* max, min, bounds, average, median, total, get_percentile, get_highest/lowest values
-* perform unit conversions on the data: to_unit, to_ip, to_si
-* filter based on conditional statements
-* filter based on analysis period
+    * max, min, bounds, average, median, total, get_percentile, get_highest/lowest values
+    * perform unit conversions on the data: to_unit, to_ip, to_si
+    * filter based on conditional statements
+    * filter based on analysis period
 
 The Hourly Continuous Collection should be used for all annual hourly data
 since it possesses the features of the other classes but includes
@@ -247,7 +247,7 @@ class HourlyDiscontinuousCollection(BaseCollection):
 
         -   The first represents the month of the year between 1-12.
 
-        -   The first represents the hour of the day between 0-24.
+        -   The second represents the hour of the day between 0-24.
             (eg. (12, 23) for December at 11 PM)
         """
         data_by_month_per_hour = OrderedDict()

--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -2,23 +2,24 @@
 """Ladybug Data Collections.
 
 Collections have the following inheritence structure:
-                         Base
-       ___________________|__________________
-      |             |           |            |
 
-    Hourly        Daily     Monthly     MonthlyPerHour
-Discontinuous
-      |
+.. code-block:: shell
 
-    Hourly
-  Continuous
+                             Base
+           ___________________|__________________
+          |             |           |            |
+        Hourly        Daily     Monthly     MonthlyPerHour
+    Discontinuous
+          |
+        Hourly
+      Continuous
 
 
 All Data Collections in this module have the ability to:
-    * max, min, bounds, average, median, total, get_percentile, get_highest/lowest values
-    * perform unit conversions on the data: to_unit, to_ip, to_si
-    * filter based on conditional statements
-    * filter based on analysis period
+* max, min, bounds, average, median, total, get_percentile, get_highest/lowest values
+* perform unit conversions on the data: to_unit, to_ip, to_si
+* filter based on conditional statements
+* filter based on analysis period
 
 The Hourly Continuous Collection should be used for all annual hourly data
 since it possesses the features of the other classes but includes
@@ -47,19 +48,39 @@ except ImportError:
 
 
 class HourlyDiscontinuousCollection(BaseCollection):
-    """Discontinous Data Collection at hourly or sub-hourly intervals."""
+    """Discontinous Data Collection at hourly or sub-hourly intervals.
+
+    Args:
+        header: A Ladybug Header object.  Note that this header
+            must have an AnalysisPeriod on it.
+        values: A list of values.
+        datetimes: A list of Ladybug DateTime objects that aligns with
+            the list of values.
+
+
+    Properties:
+        * average
+        * bounds
+        * datetimes
+        * header
+        * isDataCollection
+        * isHourly
+        * is_continuous
+        * is_mutable
+        * max
+        * median
+        * min
+        * moys_dict
+        * timestep_text
+        * total
+        * validated_a_period
+        * values
+    """
 
     _collection_type = 'HourlyDiscontinuous'
 
     def __init__(self, header, values, datetimes):
         """Initialize hourly discontinuous collection.
-
-        Args:
-            header: A Ladybug Header object.  Note that this header
-                must have an AnalysisPeriod on it.
-            values: A list of values.
-            datetimes: A list of Ladybug DateTime objects that aligns with
-                the list of values.
         """
         assert isinstance(header, Header), \
             'header must be a Ladybug Header object. Got {}'.format(type(header))
@@ -79,12 +100,16 @@ class HourlyDiscontinuousCollection(BaseCollection):
         """Create a Data Collection from a dictionary.
 
         Args:
-            {
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+                {
                 "header": A Ladybug Header,
                 "values": An array of values,
                 "datetimes": An array of datetimes,
                 "validated_a_period": Boolean for whether header analysis_period is valid
-            }
+                }
         """
         assert 'header' in data, 'Required keyword "header" is missing!'
         assert 'values' in data, 'Required keyword "values" is missing!'
@@ -217,10 +242,12 @@ class HourlyDiscontinuousCollection(BaseCollection):
     def group_by_month_per_hour(self):
         """Return a dictionary of this collection's values grouped by each month per hour.
 
-        Key values are tuples of 2 integers:
-        The first represents the month of the year between 1-12.
-        The first represents the hour of the day between 0-24.
-        (eg. (12, 23) for December at 11 PM)
+        Key values are tuples of 2 integers.
+
+        -   The first represents the month of the year between 1-12.
+
+        -   The first represents the hour of the day between 0-24.
+            (eg. (12, 23) for December at 11 PM)
         """
         data_by_month_per_hour = OrderedDict()
         for m in xrange(1, 13):
@@ -251,9 +278,9 @@ class HourlyDiscontinuousCollection(BaseCollection):
         """Linearly interpolate over holes in this collection to make it continuous.
 
         Returns:
-            continuous_collection: A HourlyContinuousCollection with the same data
-                as this collection but with missing data filled by means of a
-                linear interpolation.
+            continuous_collection -- A HourlyContinuousCollection with the same data
+            as this collection but with missing data filled by means of a
+            linear interpolation.
         """
         # validate analysis_period and use the resulting period to generate datetimes
         assert self.validated_a_period is True, 'validated_a_period property must be' \
@@ -318,12 +345,18 @@ class HourlyDiscontinuousCollection(BaseCollection):
         """Get a collection where the header analysis_period aligns with datetimes.
 
         This means that checks for five criteria will be performed:
-        1) All datetimes in the data collection are in chronological orderstarting
+
+        1)  All datetimes in the data collection are in chronological order starting
             from the analysis_period start hour to the end hour.
-        2) No duplicate datetimes exist in the data collection.
-        3) There are no datetimes that lie outside of the analysis_period time range.
-        4) There are no datetimes that do not align with the analysis_period timestep.
-        5) Datetimes for February 29th are excluded if is_leap_year is False on
+
+        2)  No duplicate datetimes exist in the data collection.
+
+        3)  There are no datetimes that lie outside of the analysis_period time range.
+
+        4)  There are no datetimes that do not align with the analysis_period
+            timestep.
+
+        5)  Datetimes for February 29th are excluded if is_leap_year is False on
             the analysis_period.
 
         Note that there is no need to run this check any time that a discontinous
@@ -509,19 +542,39 @@ class HourlyDiscontinuousCollection(BaseCollection):
 
 
 class HourlyContinuousCollection(HourlyDiscontinuousCollection):
-    """Class for Continouus Data Collections at hourly or sub-hourly intervals."""
+    """Class for Continouus Data Collections at hourly or sub-hourly intervals.
+
+    Args:
+        header: A Ladybug Header object.  Note that this header
+            must have an AnalysisPeriod on it that aligns with the
+            list of values.
+        values: A list of values.  Note that the length of this list
+            must align with the AnalysisPeriod on the header.
+
+    Properties:
+        * average
+        * bounds
+        * datetimes
+        * header
+        * isContinuous
+        * isDataCollection
+        * isHourly
+        * is_continuous
+        * is_mutable
+        * max
+        * median
+        * min
+        * moys_dict
+        * timestep_text
+        * total
+        * validated_a_period
+        * values
+    """
 
     _collection_type = 'HourlyContinuous'
 
     def __init__(self, header, values):
         """Initialize hourly discontinuous collection.
-
-        Args:
-            header: A Ladybug Header object.  Note that this header
-                must have an AnalysisPeriod on it that aligns with the
-                list of values.
-            values: A list of values.  Note that the length of this list
-                must align with the AnalysisPeriod on the header.
         """
         assert isinstance(header, Header), \
             'header must be a Ladybug Header object. Got {}'.format(type(header))
@@ -544,10 +597,14 @@ class HourlyContinuousCollection(HourlyDiscontinuousCollection):
         """Create a Data Collection from a dictionary.
 
         Args:
-            {
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+                {
                 "header": A Ladybug Header,
                 "values": An array of values,
-            }
+                }
         """
         assert 'header' in data, 'Required keyword "header" is missing!'
         assert 'values' in data, 'Required keyword "values" is missing!'
@@ -582,7 +639,7 @@ class HourlyContinuousCollection(HourlyDiscontinuousCollection):
 
         Return:
             A continuous hourly data collection with data interpolated to
-                the input timestep.
+            the input timestep.
         """
         assert timestep % self.header.analysis_period.timestep == 0, \
             'Target timestep({}) must be divisable by current timestep({})' \
@@ -844,7 +901,7 @@ class HourlyContinuousCollection(HourlyDiscontinuousCollection):
                 collection is aligned with.
 
         Return:
-            True if collections are aligned, Fale if not aligned
+            True if collections are aligned, False if not aligned
         """
         if self._collection_type != data_collection._collection_type:
             return False
@@ -935,20 +992,37 @@ class HourlyContinuousCollection(HourlyDiscontinuousCollection):
 
 
 class DailyCollection(BaseCollection):
-    """Class for Daily Data Collections."""
+    """Class for Daily Data Collections.
 
+    Args:
+        header: A Ladybug Header object.  Note that this header
+            must have an AnalysisPeriod on it.
+        values: A list of values.
+        datetimes: A list of integers that aligns with the list of values.
+            Each integer in the list is 1-365 and denotes the day of the
+            year for each value of the collection.
+
+    Properties:
+        * average
+        * bounds
+        * datetimes
+        * header
+        * isDataCollection
+        * isMonthlyPerHour
+        * isHourly
+        * is_continuous
+        * is_mutable
+        * max
+        * median
+        * min
+        * total
+        * validated_a_period
+        * values
+    """
     _collection_type = 'Daily'
 
     def __init__(self, header, values, datetimes):
         """Initialize daily collection.
-
-        Args:
-            header: A Ladybug Header object.  Note that this header
-                must have an AnalysisPeriod on it.
-            values: A list of values.
-            datetimes: A list of integers that aligns with the list of values.
-                Each integer in the list is 1-365 and denotes the day of the
-                year for each value of the collection.
         """
         assert isinstance(header, Header), \
             'header must be a Ladybug Header object. Got {}'.format(type(header))
@@ -1029,11 +1103,15 @@ class DailyCollection(BaseCollection):
         """Get a collection where the header analysis_period aligns with datetimes.
 
         This means that checks for four criteria will be performed:
-        1) All days in the data collection are chronological starting from the
+
+        1)  All days in the data collection are chronological starting from the
             analysis_period start day to the end day.
-        2) No duplicate days exist in the data collection.
-        3) There are no days that lie outside of the analysis_period time range.
-        4) February 29th is excluded if is_leap_year is False on the analysis_period.
+
+        2)  No duplicate days exist in the data collection.
+
+        3)  There are no days that lie outside of the analysis_period time range.
+
+        4)  February 29th is excluded if is_leap_year is False on the analysis_period.
 
         Note that there is no need to run this check any time that a discontinous
         data collection has been derived from a continuous one or when the
@@ -1148,20 +1226,38 @@ class DailyCollection(BaseCollection):
 
 
 class MonthlyCollection(BaseCollection):
-    """Class for Monthly Data Collections."""
+    """Class for Monthly Data Collections.
+
+    Args:
+        header: A Ladybug Header object.  Note that this header
+            must have an AnalysisPeriod on it.
+        values: A list of values.
+        datetimes: A list of integers that aligns with the list of values.
+            Each integer in the list is 1-12 and denotes the month of the
+            year for each value of the collection.
+
+    Properties:
+        * average
+        * bounds
+        * datetimes
+        * header
+        * isDataCollection
+        * isMonthlyPerHour
+        * isHourly
+        * is_continuous
+        * is_mutable
+        * max
+        * median
+        * min
+        * total
+        * validated_a_period
+        * values
+    """
 
     _collection_type = 'Monthly'
 
     def __init__(self, header, values, datetimes):
         """Initialize monthly collection.
-
-        Args:
-            header: A Ladybug Header object.  Note that this header
-                must have an AnalysisPeriod on it.
-            values: A list of values.
-            datetimes: A list of integers that aligns with the list of values.
-                Each integer in the list is 1-12 and denotes the month of the
-                year for each value of the collection.
         """
         assert isinstance(header, Header), \
             'header must be a Ladybug Header object. Got {}'.format(type(header))
@@ -1211,10 +1307,13 @@ class MonthlyCollection(BaseCollection):
         """Get a collection where the header analysis_period aligns with datetimes.
 
         This means that checks for three criteria will be performed:
-        1) All months in the data collection are chronological starting from the
+
+        1)  All months in the data collection are chronological starting from the
             analysis_period start month to the end month.
-        2) No duplicate months exist in the data collection.
-        3) There are no months that lie outside of the analysis_period range.
+
+        2)  No duplicate months exist in the data collection.
+
+        3)  There are no months that lie outside of the analysis_period range.
 
         Note that there is no need to run this check any time that a
         data collection has been derived from a continuous one or when the
@@ -1280,20 +1379,38 @@ class MonthlyCollection(BaseCollection):
 
 
 class MonthlyPerHourCollection(BaseCollection):
-    """Class for Monthly Per Hour Collections."""
+    """Class for Monthly Per Hour Collections.
+
+    Args:
+        header: A Ladybug Header object.  Note that this header
+            must have an AnalysisPeriod on it.
+        values: A list of values.
+        datetimes: A list of tuples that aligns with the list of values.
+            Each tuple should possess two values: the first is the month
+            and the second is the hour. (eg. (12, 23) = December at 11 PM)
+
+    Properties:
+        * average
+        * bounds
+        * datetimes
+        * header
+        * isDataCollection
+        * isMonthlyPerHour
+        * isHourly
+        * is_continuous
+        * is_mutable
+        * max
+        * median
+        * min
+        * total
+        * validated_a_period
+        * values
+    """
 
     _collection_type = 'MonthlyPerHour'
 
     def __init__(self, header, values, datetimes):
         """Initialize monthly per hour collection.
-
-        Args:
-            header: A Ladybug Header object.  Note that this header
-                must have an AnalysisPeriod on it.
-            values: A list of values.
-            datetimes: A list of tuples that aligns with the list of values.
-                Each tuple should possess two values: the first is the month
-                and the second is the hour. (eg. (12, 23) = December at 11 PM)
         """
         assert isinstance(header, Header), \
             'header must be a Ladybug Header object. Got {}'.format(type(header))
@@ -1346,10 +1463,13 @@ class MonthlyPerHourCollection(BaseCollection):
         """Get a collection where the header analysis_period aligns with datetimes.
 
         This means that checks for three criteria will be performed:
-        1) All datetimes in the data collection are chronological starting from the
+
+        1)  All datetimes in the data collection are chronological starting from the
             analysis_period start datetime to the end datetime.
-        2) No duplicate datetimes exist in the data collection.
-        3) There are no datetimes that lie outside of the analysis_period range.
+
+        2)  No duplicate datetimes exist in the data collection.
+
+        3)  There are no datetimes that lie outside of the analysis_period range.
 
         Note that there is no need to run this check any time that a
         data collection has been derived from a continuous one or when the

--- a/ladybug/datacollectionimmutable.py
+++ b/ladybug/datacollectionimmutable.py
@@ -5,11 +5,14 @@ Note that all of the methods or properties on an immutable collection that
 return another data collection will return a collection that is mutable.
 
 The only exceptions to this rule are:
-duplicate() - which will always return an exact copy of the collection including
+
+*   duplicate() - which will always return an exact copy of the collection including
     its mutabiliy.
-get_aligned_collection() - which follows the mutability of the starting collection
+
+*   get_aligned_collection() - which follows the mutability of the starting collection
     by default but includes an parameter to override this.
-to_immutable() - which clearly always returns an immutable version of the collection
+
+*   to_immutable() - which clearly always returns an immutable version of the collection
 
 Note that the to_mutable() method on the immutable collections can always be used to
 get a mutable version of an immutable collection.

--- a/ladybug/datatype/__init__.py
+++ b/ladybug/datatype/__init__.py
@@ -6,12 +6,15 @@ It also includes descriptions of the data types and the units.
 
 Properties:
     TYPES: A tuple indicating all currently supported data types.
+
     BASETYPES: A tuple indicating all base types. Base types are the
-        data types on which unit systems are defined.
+    data types on which unit systems are defined.
+
     UNITS: A dictionary containing all currently supported units. The
-        keys of this dictionary are the base type names (eg. 'Temperature').
+    keys of this dictionary are the base type names (eg. 'Temperature').
+
     TYPESDICT: A dictionary containing pointers to the classes of each data type.
-        The keys of this dictionary are the data type names.
+    The keys of this dictionary are the data type names.
 """
 
 from .base import _DataTypeEnumeration

--- a/ladybug/datatype/angle.py
+++ b/ladybug/datatype/angle.py
@@ -10,18 +10,6 @@ PI = math.pi
 
 class Angle(DataTypeBase):
     """Angle
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('degrees', 'radians')
     _si_units = ('degrees', 'radians')
@@ -53,19 +41,5 @@ class Angle(DataTypeBase):
 
 
 class WindDirection(Angle):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
-
     _name = 'Wind Direction'
     _abbreviation = 'WD'

--- a/ladybug/datatype/angle.py
+++ b/ladybug/datatype/angle.py
@@ -9,7 +9,43 @@ PI = math.pi
 
 
 class Angle(DataTypeBase):
-    """Angle"""
+    """Angle
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isAngle
+        *   isDataType
+    """
     _units = ('degrees', 'radians')
     _si_units = ('degrees', 'radians')
     _ip_units = ('degrees', 'radians')
@@ -40,5 +76,42 @@ class Angle(DataTypeBase):
 
 
 class WindDirection(Angle):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isAngle
+        *   isDataType
+    """
+
     _name = 'Wind Direction'
     _abbreviation = 'WD'

--- a/ladybug/datatype/angle.py
+++ b/ladybug/datatype/angle.py
@@ -12,39 +12,16 @@ class Angle(DataTypeBase):
     """Angle
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isAngle
-        *   isDataType
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('degrees', 'radians')
     _si_units = ('degrees', 'radians')
@@ -78,39 +55,16 @@ class Angle(DataTypeBase):
 class WindDirection(Angle):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isAngle
-        *   isDataType
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
 
     _name = 'Wind Direction'

--- a/ladybug/datatype/area.py
+++ b/ladybug/datatype/area.py
@@ -7,19 +7,7 @@ from .base import DataTypeBase
 
 class Area(DataTypeBase):
     """Area
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-"""
+    """
     _units = ('m2', 'ft2', 'mm2', 'in2', 'km2', 'mi2', 'cm2', 'ha', 'acre')
     _si_units = ('m2', 'mm2', 'km2', 'cm2', 'ha')
     _ip_units = ('ft2', 'in2', 'mi2', 'acre')

--- a/ladybug/datatype/area.py
+++ b/ladybug/datatype/area.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class Area(DataTypeBase):
-    """Area"""
+    """Area
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isArea
+        *   isDataType
+"""
     _units = ('m2', 'ft2', 'mm2', 'in2', 'km2', 'mi2', 'cm2', 'ha', 'acre')
     _si_units = ('m2', 'mm2', 'km2', 'cm2', 'ha')
     _ip_units = ('ft2', 'in2', 'mi2', 'acre')

--- a/ladybug/datatype/area.py
+++ b/ladybug/datatype/area.py
@@ -9,39 +9,16 @@ class Area(DataTypeBase):
     """Area
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isArea
-        *   isDataType
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
 """
     _units = ('m2', 'ft2', 'mm2', 'in2', 'km2', 'mi2', 'cm2', 'ha', 'acre')
     _si_units = ('m2', 'mm2', 'km2', 'cm2', 'ha')

--- a/ladybug/datatype/base.py
+++ b/ladybug/datatype/base.py
@@ -231,14 +231,18 @@ class DataTypeBase(object):
 
     @property
     def min(self):
-        """Lower limit for the data type, values below which should be physically
+        """Lower limit for the data type.
+
+        Values below lower limit should be physically
         or mathematically impossible. (Default: -inf)
         """
         return self._min
 
     @property
     def max(self):
-        """ Upper limit for the data type, values above which should be physically
+        """ Upper limit for the data type.
+
+        Values above upper limit should be physically
         or mathematically impossible. (Default: +inf)
         """
         return self._max
@@ -255,9 +259,10 @@ class DataTypeBase(object):
 
     @property
     def unit_descr(self):
-        """An optional dictionary describing categories that the numerical
-        values of the units relate to.
+        """A description of the data type units
 
+        A dictionary is used to describe categories that the numerical values of
+        the units relate to.
         This is useful if numerical values of the units relate to specific categories.
         (eg. -1 = Cold, 0 = Neutral, +1 = Hot) (eg. 0 = False, 1 = True).
         """
@@ -265,21 +270,23 @@ class DataTypeBase(object):
 
     @property
     def point_in_time(self):
-        """Boolean to note whether the data type represents conditions
+        """"Whether the data type is point_in_time.
+
+        A Boolean indicates whether the data type represents conditions
         at a single instant in time (True) as opposed to being an average or
         accumulation over time (False) when it is found in hourly lists of data.
-
         (True Examples: Temperature, WindSpeed)
         (False Examples: Energy, Radiation, Illuminance)"""
         return self._point_in_time
 
     @property
     def cumulative(self):
-        """Boolean to tell whether the data type can be cumulative when it
+        """Whether the data type is cumulative.
+
+        A Boolean to tell whether the data type can be cumulative when it
         is represented over time (True) or it can only be averaged over time
         to be meaningful (False). Note that cumulative cannot be True
         when point_in_time is also True.
-
         (False Examples: Temperature, Irradiance, Illuminance)
         (True Examples: Energy, Radiation)
         """

--- a/ladybug/datatype/base.py
+++ b/ladybug/datatype/base.py
@@ -272,9 +272,9 @@ class DataTypeBase(object):
     def point_in_time(self):
         """"Whether the data type is point_in_time.
 
-        A Boolean indicates whether the data type represents conditions
-        at a single instant in time (True) as opposed to being an average or
-        accumulation over time (False) when it is found in hourly lists of data.
+        A Boolean indicates that the data type represents conditions
+        at a single instant in time (True) or at an average or
+        accumulation over time (False) when found in hourly lists of data.
         (True Examples: Temperature, WindSpeed)
         (False Examples: Energy, Radiation, Illuminance)"""
         return self._point_in_time
@@ -283,7 +283,7 @@ class DataTypeBase(object):
     def cumulative(self):
         """Whether the data type is cumulative.
 
-        A Boolean to tell whether the data type can be cumulative when it
+        A Boolean indicates that the data type can be cumulative when it
         is represented over time (True) or it can only be averaged over time
         to be meaningful (False). Note that cumulative cannot be True
         when point_in_time is also True.

--- a/ladybug/datatype/base.py
+++ b/ladybug/datatype/base.py
@@ -11,38 +11,42 @@ import re
 class DataTypeBase(object):
     """Base class for data types.
 
+    Args:
+        name: Optional name for the type. Default is derived from the class name.
+
     Properties:
-        name: The full name of the data type as a string.
-        units: A list of all accetpable units of the data type as abbreviated text.
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
             The first item of the list should be the standard SI unit.
             The second item of the list should be the stadard IP unit (if it exists).
             The rest of the list can be any other acceptable units.
             (eg. [C, F, K])
-        si_units: A list of acceptable SI units.
-        ip_units: A list of acceptable IP units.
-        min: Lower limit for the data type, values below which should be physically
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
             or mathematically impossible. (Default: -inf)
-        max: Upper limit for the data type, values above which should be physically
+        *   max: Upper limit for the data type, values above which should be physically
             or mathematically impossible. (Default: +inf)
-        abbreviation: An optional abbreviation for the data type as text.
+        *   abbreviation: An optional abbreviation for the data type as text.
             (eg. 'UTCI' for Universal Thermal Climate Index).
             This can also be a letter that represents the data type in a formula.
             (eg. 'A' for Area; 'P' for Pressure)
-        unit_descr: An optional dictionary describing categories that the numerical
+        *   unit_descr: An optional dictionary describing categories that the numerical
             values of the units relate to. For example:
             {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
             {0: 'False', 1: 'True'}
-        point_in_time: Boolean to note whether the data type represents conditions
+        *   point_in_time: Boolean to note whether the data type represents conditions
             at a single instant in time (True) as opposed to being an average or
             accumulation over time (False) when it is found in hourly lists of data.
             (True Examples: Temperature, WindSpeed)
             (False Examples: Energy, Radiation, Illuminance)
-        cumulative: Boolean to tell whether the data type can be cumulative when it
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
             is represented over time (True) or it can only be averaged over time
             to be meaningful (False). Note that cumulative cannot be True
             when point_in_time is also True.
             (False Examples: Temperature, Irradiance, Illuminance)
             (True Examples: Energy, Radiation)
+        *   isDataType
     """
     _name = None
     _units = [None]
@@ -60,9 +64,6 @@ class DataTypeBase(object):
 
     def __init__(self, name=None):
         """Initialize DataType.
-
-        Args:
-            name: Optional name for the type. Default is derived from the class name.
         """
         self._name = name
 
@@ -71,7 +72,10 @@ class DataTypeBase(object):
         """Create a data type from a dictionary.
 
         Args:
-            data: Data as a dictionary.
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
                 {
                     "name": data type name of the data type as a string
                     "data_type": the class name of the data type as a string

--- a/ladybug/datatype/base.py
+++ b/ladybug/datatype/base.py
@@ -270,13 +270,14 @@ class DataTypeBase(object):
 
     @property
     def point_in_time(self):
-        """"Whether the data type is point_in_time.
+        """Whether the data type is point_in_time.
 
         A Boolean indicates that the data type represents conditions
         at a single instant in time (True) or at an average or
         accumulation over time (False) when found in hourly lists of data.
         (True Examples: Temperature, WindSpeed)
-        (False Examples: Energy, Radiation, Illuminance)"""
+        (False Examples: Energy, Radiation, Illuminance)
+        """
         return self._point_in_time
 
     @property

--- a/ladybug/datatype/base.py
+++ b/ladybug/datatype/base.py
@@ -15,38 +15,16 @@ class DataTypeBase(object):
         name: Optional name for the type. Default is derived from the class name.
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _name = None
     _units = [None]
@@ -74,12 +52,12 @@ class DataTypeBase(object):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
                 {
-                    "name": data type name of the data type as a string
-                    "data_type": the class name of the data type as a string
-                    "base_unit": the base unit of the data type
+                    "name": n  # data type name of the data type as a string
+                    "data_type": t  # the class name of the data type as a string
+                    "base_unit": b  # the base unit of the data type
                 }
         """
         assert 'name' in data, 'Required keyword "name" is missing!'
@@ -224,7 +202,7 @@ class DataTypeBase(object):
 
     @property
     def name(self):
-        """The data type name."""
+        """The full name of the data type as a string."""
         if self._name is None:
             return re.sub(r"(?<=\w)([A-Z])", r" \1", self.__class__.__name__)
         else:
@@ -232,7 +210,13 @@ class DataTypeBase(object):
 
     @property
     def units(self):
-        """A tuple of all acceptable units for the data type."""
+        """A tuple of all accetpable units of the data type as abbreviated text.
+
+        The first item of the list should be the standard SI unit.
+        The second item of the list should be the stadard IP unit (if it exists).
+        The rest of the list can be any other acceptable units.
+        (eg. [C, F, K])
+        """
         return self._units
 
     @property
@@ -247,22 +231,32 @@ class DataTypeBase(object):
 
     @property
     def min(self):
-        """The minimum possible value of the data type."""
+        """Lower limit for the data type, values below which should be physically
+        or mathematically impossible. (Default: -inf)
+        """
         return self._min
 
     @property
     def max(self):
-        """The maximum possible value of the data type."""
+        """ Upper limit for the data type, values above which should be physically
+        or mathematically impossible. (Default: +inf)
+        """
         return self._max
 
     @property
     def abbreviation(self):
-        """The abbreviation of the data type."""
+        """An optional abbreviation for the data type as text.
+
+        (eg. 'UTCI' for Universal Thermal Climate Index).
+        This can also be a letter that represents the data type in a formula.
+        (eg. 'A' for Area; 'P' for Pressure)
+        """
         return self._abbreviation
 
     @property
     def unit_descr(self):
-        """A description of the data type units.
+        """An optional dictionary describing categories that the numerical
+        values of the units relate to.
 
         This is useful if numerical values of the units relate to specific categories.
         (eg. -1 = Cold, 0 = Neutral, +1 = Hot) (eg. 0 = False, 1 = True).
@@ -271,12 +265,24 @@ class DataTypeBase(object):
 
     @property
     def point_in_time(self):
-        """Whether the data type is point_in_time."""
+        """Boolean to note whether the data type represents conditions
+        at a single instant in time (True) as opposed to being an average or
+        accumulation over time (False) when it is found in hourly lists of data.
+
+        (True Examples: Temperature, WindSpeed)
+        (False Examples: Energy, Radiation, Illuminance)"""
         return self._point_in_time
 
     @property
     def cumulative(self):
-        """Whether the data type is cumulative."""
+        """Boolean to tell whether the data type can be cumulative when it
+        is represented over time (True) or it can only be averaged over time
+        to be meaningful (False). Note that cumulative cannot be True
+        when point_in_time is also True.
+
+        (False Examples: Temperature, Irradiance, Illuminance)
+        (True Examples: Energy, Radiation)
+        """
         return self._cumulative
 
     @property

--- a/ladybug/datatype/base.py
+++ b/ladybug/datatype/base.py
@@ -55,9 +55,9 @@ class DataTypeBase(object):
         .. code-block:: python
 
                 {
-                    "name": n  # data type name of the data type as a string
-                    "data_type": t  # the class name of the data type as a string
-                    "base_unit": b  # the base unit of the data type
+                    "name": ""  # data type name of the data type as a string
+                    "data_type": ""  # the class name of the data type as a string
+                    "base_unit": ""  # the base unit of the data type
                 }
         """
         assert 'name' in data, 'Required keyword "name" is missing!'

--- a/ladybug/datatype/distance.py
+++ b/ladybug/datatype/distance.py
@@ -7,18 +7,6 @@ from .base import DataTypeBase
 
 class Distance(DataTypeBase):
     """Distance
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('m', 'ft', 'mm', 'in', 'km', 'mi', 'cm')
     _si_units = ('m', 'mm', 'km', 'cm')
@@ -96,41 +84,6 @@ class Distance(DataTypeBase):
 
 class Visibility(Distance):
     """Visibility
-
-    Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDistance
-        *   isDataType
     """
     _abbreviation = 'Vis'
     _missing_epw = 9999
@@ -138,41 +91,6 @@ class Visibility(Distance):
 
 class CeilingHeight(Distance):
     """CeilingHeight
-
-    Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDistance
-        *   isDataType
     """
     _abbreviation = 'Hciel'
     _missing_epw = 99999
@@ -180,41 +98,6 @@ class CeilingHeight(Distance):
 
 class PrecipitableWater(Distance):
     """PrecipitableWater
-
-    Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDistance
-        *   isDataType
     """
     _abbreviation = 'PW'
     _missing_epw = 999
@@ -222,41 +105,6 @@ class PrecipitableWater(Distance):
 
 class SnowDepth(Distance):
     """SnowDepth
-
-    Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDistance
-        *   isDataType
     """
     _abbreviation = 'Dsnow'
     _missing_epw = 999
@@ -264,41 +112,6 @@ class SnowDepth(Distance):
 
 class LiquidPrecipitationDepth(Distance):
     """LiquidPrecipitationDepth
-
-    Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDistance
-        *   isDataType
     """
     _abbreviation = 'LPD'
     _missing_epw = 999

--- a/ladybug/datatype/distance.py
+++ b/ladybug/datatype/distance.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class Distance(DataTypeBase):
-    """Distance"""
+    """Distance
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDistance
+        *   isDataType
+    """
     _units = ('m', 'ft', 'mm', 'in', 'km', 'mi', 'cm')
     _si_units = ('m', 'mm', 'km', 'cm')
     _ip_units = ('ft', 'in', 'mi')
@@ -82,25 +118,210 @@ class Distance(DataTypeBase):
 
 
 class Visibility(Distance):
+    """Visibility
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDistance
+        *   isDataType
+    """
     _abbreviation = 'Vis'
     _missing_epw = 9999
 
 
 class CeilingHeight(Distance):
+    """CeilingHeight
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDistance
+        *   isDataType
+    """
     _abbreviation = 'Hciel'
     _missing_epw = 99999
 
 
 class PrecipitableWater(Distance):
+    """PrecipitableWater
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDistance
+        *   isDataType
+    """
     _abbreviation = 'PW'
     _missing_epw = 999
 
 
 class SnowDepth(Distance):
+    """SnowDepth
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDistance
+        *   isDataType
+    """
     _abbreviation = 'Dsnow'
     _missing_epw = 999
 
 
 class LiquidPrecipitationDepth(Distance):
+    """LiquidPrecipitationDepth
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDistance
+        *   isDataType
+    """
     _abbreviation = 'LPD'
     _missing_epw = 999

--- a/ladybug/datatype/distance.py
+++ b/ladybug/datatype/distance.py
@@ -9,39 +9,16 @@ class Distance(DataTypeBase):
     """Distance
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDistance
-        *   isDataType
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('m', 'ft', 'mm', 'in', 'km', 'mi', 'cm')
     _si_units = ('m', 'mm', 'km', 'cm')

--- a/ladybug/datatype/energy.py
+++ b/ladybug/datatype/energy.py
@@ -6,7 +6,44 @@ from .base import DataTypeBase
 
 
 class Energy(DataTypeBase):
-    """Energy"""
+    """Energy
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isEnergy
+        *   isDataType
+
+    """
     _units = ('kWh', 'kBtu', 'Wh', 'Btu', 'MMBtu', 'J', 'kJ', 'MJ', 'GJ',
               'therm', 'cal', 'kcal')
     _si_units = ('kWh', 'Wh', 'J', 'kJ', 'MJ', 'GJ')

--- a/ladybug/datatype/energy.py
+++ b/ladybug/datatype/energy.py
@@ -9,39 +9,16 @@ class Energy(DataTypeBase):
     """Energy
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isEnergy
-        *   isDataType
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
 
     """
     _units = ('kWh', 'kBtu', 'Wh', 'Btu', 'MMBtu', 'J', 'kJ', 'MJ', 'GJ',

--- a/ladybug/datatype/energy.py
+++ b/ladybug/datatype/energy.py
@@ -7,19 +7,6 @@ from .base import DataTypeBase
 
 class Energy(DataTypeBase):
     """Energy
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-
     """
     _units = ('kWh', 'kBtu', 'Wh', 'Btu', 'MMBtu', 'J', 'kJ', 'MJ', 'GJ',
               'therm', 'cal', 'kcal')

--- a/ladybug/datatype/energyflux.py
+++ b/ladybug/datatype/energyflux.py
@@ -7,18 +7,6 @@ from .base import DataTypeBase
 
 class EnergyFlux(DataTypeBase):
     """Energy Flux
-
-    Properties:
-            *   name
-            *   units
-            *   si_units
-            *   ip_units
-            *   min
-            *   max
-            *   abbreviation
-            *   unit_descr
-            *   point_in_time
-            *   cumulative
     """
     _units = ('W/m2', 'Btu/h-ft2', 'kW/m2', 'kBtu/h-ft2', 'W/ft2', 'met')
     _si_units = ('W/m2', 'kW/m2')
@@ -85,57 +73,15 @@ class EnergyFlux(DataTypeBase):
 
 
 class MetabolicRate(EnergyFlux):
-    """
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _min = 0
     _abbreviation = 'MetR'
 
 
 class EffectiveRadiantField(EnergyFlux):
-    """
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'ERF'
 
 
 class Irradiance(EnergyFlux):
-    """
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _min = 0
     _abbreviation = 'Qsolar'
 
@@ -146,91 +92,21 @@ class Irradiance(EnergyFlux):
 
 
 class GlobalHorizontalIrradiance(Irradiance):
-    """
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'GHIr'
 
 
 class DirectNormalIrradiance(Irradiance):
-    """
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'DNIr'
 
 
 class DiffuseHorizontalIrradiance(Irradiance):
-    """
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'DHIr'
 
 
 class DirectHorizontalIrradiance(Irradiance):
-    """
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'DHIr'
 
 
 class HorizontalInfraredRadiationIntensity(Irradiance):
-    """
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'HIr'
     _point_in_time = True

--- a/ladybug/datatype/energyflux.py
+++ b/ladybug/datatype/energyflux.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class EnergyFlux(DataTypeBase):
-    """Energy Flux"""
+    """Energy Flux
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isEnergyFlux
+        *   isDataType
+    """
     _units = ('W/m2', 'Btu/h-ft2', 'kW/m2', 'kBtu/h-ft2', 'W/ft2', 'met')
     _si_units = ('W/m2', 'kW/m2')
     _ip_units = ('Btu/h-ft2', 'kBtu/h-ft2')
@@ -72,15 +108,127 @@ class EnergyFlux(DataTypeBase):
 
 
 class MetabolicRate(EnergyFlux):
+    """
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isEnergyFlux
+        *   isDataType
+    """
     _min = 0
     _abbreviation = 'MetR'
 
 
 class EffectiveRadiantField(EnergyFlux):
+    """
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isEnergyFlux
+        *   isDataType
+    """
     _abbreviation = 'ERF'
 
 
 class Irradiance(EnergyFlux):
+    """
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isEnergyFlux
+        *   isIrradiance
+        *   isDataType
+    """
     _min = 0
     _abbreviation = 'Qsolar'
 
@@ -91,21 +239,211 @@ class Irradiance(EnergyFlux):
 
 
 class GlobalHorizontalIrradiance(Irradiance):
+    """
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isEnergyFlux
+        *   isIrradiance
+        *   isDataType
+    """
     _abbreviation = 'GHIr'
 
 
 class DirectNormalIrradiance(Irradiance):
+    """
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isEnergyFlux
+        *   isIrradiance
+        *   isDataType
+    """
     _abbreviation = 'DNIr'
 
 
 class DiffuseHorizontalIrradiance(Irradiance):
+    """
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isEnergyFlux
+        *   isIrradiance
+        *   isDataType
+    """
     _abbreviation = 'DHIr'
 
 
 class DirectHorizontalIrradiance(Irradiance):
+    """
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isEnergyFlux
+        *   isIrradiance
+        *   isDataType
+    """
     _abbreviation = 'DHIr'
 
 
 class HorizontalInfraredRadiationIntensity(Irradiance):
+    """
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isEnergyFlux
+        *   isIrradiance
+        *   isDataType
+    """
     _abbreviation = 'HIr'
     _point_in_time = True

--- a/ladybug/datatype/energyflux.py
+++ b/ladybug/datatype/energyflux.py
@@ -9,39 +9,16 @@ class EnergyFlux(DataTypeBase):
     """Energy Flux
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isEnergyFlux
-        *   isDataType
+            *   name
+            *   units
+            *   si_units
+            *   ip_units
+            *   min
+            *   max
+            *   abbreviation
+            *   unit_descr
+            *   point_in_time
+            *   cumulative
     """
     _units = ('W/m2', 'Btu/h-ft2', 'kW/m2', 'kBtu/h-ft2', 'W/ft2', 'met')
     _si_units = ('W/m2', 'kW/m2')
@@ -111,39 +88,16 @@ class MetabolicRate(EnergyFlux):
     """
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isEnergyFlux
-        *   isDataType
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _min = 0
     _abbreviation = 'MetR'
@@ -153,39 +107,16 @@ class EffectiveRadiantField(EnergyFlux):
     """
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isEnergyFlux
-        *   isDataType
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'ERF'
 
@@ -194,40 +125,16 @@ class Irradiance(EnergyFlux):
     """
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isEnergyFlux
-        *   isIrradiance
-        *   isDataType
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _min = 0
     _abbreviation = 'Qsolar'
@@ -242,40 +149,16 @@ class GlobalHorizontalIrradiance(Irradiance):
     """
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isEnergyFlux
-        *   isIrradiance
-        *   isDataType
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'GHIr'
 
@@ -284,40 +167,16 @@ class DirectNormalIrradiance(Irradiance):
     """
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isEnergyFlux
-        *   isIrradiance
-        *   isDataType
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'DNIr'
 
@@ -326,40 +185,16 @@ class DiffuseHorizontalIrradiance(Irradiance):
     """
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isEnergyFlux
-        *   isIrradiance
-        *   isDataType
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'DHIr'
 
@@ -368,40 +203,16 @@ class DirectHorizontalIrradiance(Irradiance):
     """
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isEnergyFlux
-        *   isIrradiance
-        *   isDataType
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'DHIr'
 
@@ -410,40 +221,16 @@ class HorizontalInfraredRadiationIntensity(Irradiance):
     """
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isEnergyFlux
-        *   isIrradiance
-        *   isDataType
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'HIr'
     _point_in_time = True

--- a/ladybug/datatype/energyintensity.py
+++ b/ladybug/datatype/energyintensity.py
@@ -7,18 +7,6 @@ from .base import DataTypeBase
 
 class EnergyIntensity(DataTypeBase):
     """Energy Intensity
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('kWh/m2', 'kBtu/ft2', 'Wh/m2', 'Btu/ft2')
     _si_units = ('kWh/m2', 'Wh/m2')
@@ -74,19 +62,6 @@ class EnergyIntensity(DataTypeBase):
 
 
 class Radiation(EnergyIntensity):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _min = 0
     _abbreviation = 'Esolar'
 
@@ -97,102 +72,24 @@ class Radiation(EnergyIntensity):
 
 
 class GlobalHorizontalRadiation(Radiation):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'GHR'
 
 
 class DirectNormalRadiation(Radiation):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'DNR'
 
 
 class DiffuseHorizontalRadiation(Radiation):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'DHR'
 
 
 class DirectHorizontalRadiation(Radiation):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'DR'
 
 
 class ExtraterrestrialHorizontalRadiation(Radiation):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'HRex'
 
 
 class ExtraterrestrialDirectNormalRadiation(Radiation):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'DNRex'

--- a/ladybug/datatype/energyintensity.py
+++ b/ladybug/datatype/energyintensity.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class EnergyIntensity(DataTypeBase):
-    """Energy Intensity"""
+    """Energy Intensity
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isEnergyIntensity
+    """
     _units = ('kWh/m2', 'kBtu/ft2', 'Wh/m2', 'Btu/ft2')
     _si_units = ('kWh/m2', 'Wh/m2')
     _ip_units = ('kBtu/ft2', 'Btu/ft2')
@@ -61,6 +97,43 @@ class EnergyIntensity(DataTypeBase):
 
 
 class Radiation(EnergyIntensity):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isEnergyIntensity
+        *   isRadiation
+    """
     _min = 0
     _abbreviation = 'Esolar'
 
@@ -71,24 +144,246 @@ class Radiation(EnergyIntensity):
 
 
 class GlobalHorizontalRadiation(Radiation):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isEnergyIntensity
+        *   isRadiation
+    """
     _abbreviation = 'GHR'
 
 
 class DirectNormalRadiation(Radiation):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isEnergyIntensity
+        *   isRadiation
+    """
     _abbreviation = 'DNR'
 
 
 class DiffuseHorizontalRadiation(Radiation):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isEnergyIntensity
+        *   isRadiation
+    """
     _abbreviation = 'DHR'
 
 
 class DirectHorizontalRadiation(Radiation):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isEnergyIntensity
+        *   isRadiation
+    """
     _abbreviation = 'DR'
 
 
 class ExtraterrestrialHorizontalRadiation(Radiation):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isEnergyIntensity
+        *   isRadiation
+    """
     _abbreviation = 'HRex'
 
 
 class ExtraterrestrialDirectNormalRadiation(Radiation):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isEnergyIntensity
+        *   isRadiation
+    """
     _abbreviation = 'DNRex'

--- a/ladybug/datatype/energyintensity.py
+++ b/ladybug/datatype/energyintensity.py
@@ -9,39 +9,16 @@ class EnergyIntensity(DataTypeBase):
     """Energy Intensity
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isEnergyIntensity
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('kWh/m2', 'kBtu/ft2', 'Wh/m2', 'Btu/ft2')
     _si_units = ('kWh/m2', 'Wh/m2')
@@ -99,40 +76,16 @@ class EnergyIntensity(DataTypeBase):
 class Radiation(EnergyIntensity):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isEnergyIntensity
-        *   isRadiation
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _min = 0
     _abbreviation = 'Esolar'
@@ -146,40 +99,16 @@ class Radiation(EnergyIntensity):
 class GlobalHorizontalRadiation(Radiation):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isEnergyIntensity
-        *   isRadiation
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'GHR'
 
@@ -187,40 +116,16 @@ class GlobalHorizontalRadiation(Radiation):
 class DirectNormalRadiation(Radiation):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isEnergyIntensity
-        *   isRadiation
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'DNR'
 
@@ -228,40 +133,16 @@ class DirectNormalRadiation(Radiation):
 class DiffuseHorizontalRadiation(Radiation):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isEnergyIntensity
-        *   isRadiation
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'DHR'
 
@@ -269,40 +150,16 @@ class DiffuseHorizontalRadiation(Radiation):
 class DirectHorizontalRadiation(Radiation):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isEnergyIntensity
-        *   isRadiation
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'DR'
 
@@ -310,40 +167,16 @@ class DirectHorizontalRadiation(Radiation):
 class ExtraterrestrialHorizontalRadiation(Radiation):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isEnergyIntensity
-        *   isRadiation
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'HRex'
 
@@ -351,39 +184,15 @@ class ExtraterrestrialHorizontalRadiation(Radiation):
 class ExtraterrestrialDirectNormalRadiation(Radiation):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isEnergyIntensity
-        *   isRadiation
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'DNRex'

--- a/ladybug/datatype/fraction.py
+++ b/ladybug/datatype/fraction.py
@@ -7,18 +7,6 @@ from .base import DataTypeBase
 
 class Fraction(DataTypeBase):
     """Fraction
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('fraction', '%', 'tenths', 'thousandths', 'okta')
     _si_units = ('fraction', '%', 'tenths', 'thousandths', 'okta')
@@ -68,75 +56,23 @@ class Fraction(DataTypeBase):
 
 
 class PercentagePeopleDissatisfied(Fraction):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _min = 0
     _max = 1
     _abbreviation = 'PPD'
 
 
 class RelativeHumidity(Fraction):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _min = 0
     _abbreviation = 'RH'
 
 
 class HumidityRatio(Fraction):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _min = 0
     _max = 1
     _abbreviation = 'HR'
 
 
 class TotalSkyCover(Fraction):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     # (used if Horizontal IR Intensity missing)
     _min = 0
     _max = 1
@@ -144,19 +80,6 @@ class TotalSkyCover(Fraction):
 
 
 class OpaqueSkyCover(Fraction):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     # (used if Horizontal IR Intensity missing)
     _min = 0
     _max = 1
@@ -164,56 +87,17 @@ class OpaqueSkyCover(Fraction):
 
 
 class AerosolOpticalDepth(Fraction):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _min = 0
     _max = 1
     _abbreviation = 'AOD'
 
 
 class Albedo(Fraction):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _min = 0
     _max = 1
     _abbreviation = 'a'
 
 
 class LiquidPrecipitationQuantity(Fraction):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _min = 0
     _abbreviation = 'LPQ'

--- a/ladybug/datatype/fraction.py
+++ b/ladybug/datatype/fraction.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class Fraction(DataTypeBase):
-    """Fraction"""
+    """Fraction
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isFraction
+    """
     _units = ('fraction', '%', 'tenths', 'thousandths', 'okta')
     _si_units = ('fraction', '%', 'tenths', 'thousandths', 'okta')
     _ip_units = ('fraction', '%', 'tenths', 'thousandths', 'okta')
@@ -55,23 +91,167 @@ class Fraction(DataTypeBase):
 
 
 class PercentagePeopleDissatisfied(Fraction):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isFraction
+    """
     _min = 0
     _max = 1
     _abbreviation = 'PPD'
 
 
 class RelativeHumidity(Fraction):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isFraction
+    """
     _min = 0
     _abbreviation = 'RH'
 
 
 class HumidityRatio(Fraction):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isFraction
+    """
     _min = 0
     _max = 1
     _abbreviation = 'HR'
 
 
 class TotalSkyCover(Fraction):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isFraction
+    """
     # (used if Horizontal IR Intensity missing)
     _min = 0
     _max = 1
@@ -79,6 +259,42 @@ class TotalSkyCover(Fraction):
 
 
 class OpaqueSkyCover(Fraction):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isFraction
+    """
     # (used if Horizontal IR Intensity missing)
     _min = 0
     _max = 1
@@ -86,17 +302,125 @@ class OpaqueSkyCover(Fraction):
 
 
 class AerosolOpticalDepth(Fraction):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isFraction
+    """
     _min = 0
     _max = 1
     _abbreviation = 'AOD'
 
 
 class Albedo(Fraction):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isFraction
+    """
     _min = 0
     _max = 1
     _abbreviation = 'a'
 
 
 class LiquidPrecipitationQuantity(Fraction):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isFraction
+    """
     _min = 0
     _abbreviation = 'LPQ'

--- a/ladybug/datatype/fraction.py
+++ b/ladybug/datatype/fraction.py
@@ -9,39 +9,16 @@ class Fraction(DataTypeBase):
     """Fraction
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isFraction
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('fraction', '%', 'tenths', 'thousandths', 'okta')
     _si_units = ('fraction', '%', 'tenths', 'thousandths', 'okta')
@@ -93,39 +70,16 @@ class Fraction(DataTypeBase):
 class PercentagePeopleDissatisfied(Fraction):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isFraction
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _min = 0
     _max = 1
@@ -135,39 +89,16 @@ class PercentagePeopleDissatisfied(Fraction):
 class RelativeHumidity(Fraction):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isFraction
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _min = 0
     _abbreviation = 'RH'
@@ -176,39 +107,16 @@ class RelativeHumidity(Fraction):
 class HumidityRatio(Fraction):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isFraction
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _min = 0
     _max = 1
@@ -218,39 +126,16 @@ class HumidityRatio(Fraction):
 class TotalSkyCover(Fraction):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isFraction
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     # (used if Horizontal IR Intensity missing)
     _min = 0
@@ -261,39 +146,16 @@ class TotalSkyCover(Fraction):
 class OpaqueSkyCover(Fraction):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isFraction
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     # (used if Horizontal IR Intensity missing)
     _min = 0
@@ -304,39 +166,16 @@ class OpaqueSkyCover(Fraction):
 class AerosolOpticalDepth(Fraction):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isFraction
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _min = 0
     _max = 1
@@ -346,39 +185,16 @@ class AerosolOpticalDepth(Fraction):
 class Albedo(Fraction):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isFraction
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _min = 0
     _max = 1
@@ -388,39 +204,16 @@ class Albedo(Fraction):
 class LiquidPrecipitationQuantity(Fraction):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isFraction
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _min = 0
     _abbreviation = 'LPQ'

--- a/ladybug/datatype/generic.py
+++ b/ladybug/datatype/generic.py
@@ -28,18 +28,6 @@ class GenericType(DataTypeBase):
             is represented over time (True) or it can only be averaged over time
             to be meaningful (False). Note that cumulative cannot be True
             when point_in_time is also True. (Default: False)
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     def __init__(self, name, unit, min=float('-inf'), max=float('+inf'),
                  abbreviation=None, unit_descr=None, point_in_time=True,

--- a/ladybug/datatype/generic.py
+++ b/ladybug/datatype/generic.py
@@ -30,38 +30,16 @@ class GenericType(DataTypeBase):
             when point_in_time is also True. (Default: False)
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     def __init__(self, name, unit, min=float('-inf'), max=float('+inf'),
                  abbreviation=None, unit_descr=None, point_in_time=True,

--- a/ladybug/datatype/generic.py
+++ b/ladybug/datatype/generic.py
@@ -6,32 +6,67 @@ from .base import DataTypeBase
 
 
 class GenericType(DataTypeBase):
-    """Type for any data type that is not currently implemented."""
+    """Type for any data type that is not currently implemented.
+
+    Args:
+        name: A name for the data type as a string.
+        unit: A unit for the data type as a string.
+        min: Optional lower limit for the data type, values below which should be
+            physically or mathematically impossible. (Default: -inf)
+        max: Optional upper limit for the data type, values above which should be
+            physically or mathematically impossible. (Default: +inf)
+        abbreviation: An optional abbreviation for the data type as text.
+        unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (Default: True)
+        cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True. (Default: False)
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+    """
     def __init__(self, name, unit, min=float('-inf'), max=float('+inf'),
                  abbreviation=None, unit_descr=None, point_in_time=True,
                  cumulative=False):
         """Initalize Generic Type.
-
-        Args:
-            name: A name for the data type as a string.
-            unit: A unit for the data type as a string.
-            min: Optional lower limit for the data type, values below which should be
-                physically or mathematically impossible. (Default: -inf)
-            max: Optional upper limit for the data type, values above which should be
-                physically or mathematically impossible. (Default: +inf)
-            abbreviation: An optional abbreviation for the data type as text.
-            unit_descr: An optional dictionary describing categories that the numerical
-                values of the units relate to. For example:
-                {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-                {0: 'False', 1: 'True'}
-            point_in_time: Boolean to note whether the data type represents conditions
-                at a single instant in time (True) as opposed to being an average or
-                accumulation over time (False) when it is found in hourly lists of data.
-                (Default: True)
-            cumulative: Boolean to tell whether the data type can be cumulative when it
-                is represented over time (True) or it can only be averaged over time
-                to be meaningful (False). Note that cumulative cannot be True
-                when point_in_time is also True. (Default: False)
         """
         assert isinstance(name, str), 'name must be a string. Got {}.'.format(type(name))
         assert isinstance(unit, str), 'unit must be a string. Got {}.'.format(type(unit))

--- a/ladybug/datatype/illuminance.py
+++ b/ladybug/datatype/illuminance.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class Illuminance(DataTypeBase):
-    """Illuminance"""
+    """Illuminance
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isIlluminance
+    """
     _units = ('lux', 'fc')
     _si_units = ('lux')
     _ip_units = ('fc')
@@ -45,12 +81,120 @@ class Illuminance(DataTypeBase):
 
 
 class GlobalHorizontalIlluminance(Illuminance):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isIlluminance
+    """
     _abbreviation = 'GHI'
 
 
 class DirectNormalIlluminance(Illuminance):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isIlluminance
+    """
     _abbreviation = 'DNI'
 
 
 class DiffuseHorizontalIlluminance(Illuminance):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isIlluminance
+    """
     _abbreviation = 'DHI'

--- a/ladybug/datatype/illuminance.py
+++ b/ladybug/datatype/illuminance.py
@@ -9,39 +9,16 @@ class Illuminance(DataTypeBase):
     """Illuminance
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isIlluminance
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('lux', 'fc')
     _si_units = ('lux')
@@ -83,39 +60,16 @@ class Illuminance(DataTypeBase):
 class GlobalHorizontalIlluminance(Illuminance):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isIlluminance
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'GHI'
 
@@ -123,39 +77,16 @@ class GlobalHorizontalIlluminance(Illuminance):
 class DirectNormalIlluminance(Illuminance):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isIlluminance
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'DNI'
 
@@ -163,38 +94,15 @@ class DirectNormalIlluminance(Illuminance):
 class DiffuseHorizontalIlluminance(Illuminance):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isIlluminance
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'DHI'

--- a/ladybug/datatype/illuminance.py
+++ b/ladybug/datatype/illuminance.py
@@ -7,18 +7,6 @@ from .base import DataTypeBase
 
 class Illuminance(DataTypeBase):
     """Illuminance
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('lux', 'fc')
     _si_units = ('lux')
@@ -58,51 +46,12 @@ class Illuminance(DataTypeBase):
 
 
 class GlobalHorizontalIlluminance(Illuminance):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'GHI'
 
 
 class DirectNormalIlluminance(Illuminance):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'DNI'
 
 
 class DiffuseHorizontalIlluminance(Illuminance):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'DHI'

--- a/ladybug/datatype/luminance.py
+++ b/ladybug/datatype/luminance.py
@@ -7,18 +7,6 @@ from .base import DataTypeBase
 
 class Luminance(DataTypeBase):
     """Luminance
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('cd/m2', 'cd/ft2')
     _si_units = ('cd/m2')
@@ -58,17 +46,4 @@ class Luminance(DataTypeBase):
 
 
 class ZenithLuminance(Luminance):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'ZL'

--- a/ladybug/datatype/luminance.py
+++ b/ladybug/datatype/luminance.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class Luminance(DataTypeBase):
-    """Luminance"""
+    """Luminance
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isLuminance
+    """
     _units = ('cd/m2', 'cd/ft2')
     _si_units = ('cd/m2')
     _ip_units = ('cd/ft2')
@@ -45,4 +81,40 @@ class Luminance(DataTypeBase):
 
 
 class ZenithLuminance(Luminance):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isLuminance
+    """
     _abbreviation = 'ZL'

--- a/ladybug/datatype/luminance.py
+++ b/ladybug/datatype/luminance.py
@@ -9,39 +9,16 @@ class Luminance(DataTypeBase):
     """Luminance
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isLuminance
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('cd/m2', 'cd/ft2')
     _si_units = ('cd/m2')
@@ -83,38 +60,15 @@ class Luminance(DataTypeBase):
 class ZenithLuminance(Luminance):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isLuminance
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'ZL'

--- a/ladybug/datatype/mass.py
+++ b/ladybug/datatype/mass.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class Mass(DataTypeBase):
-    """Mass"""
+    """Mass
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isMass
+    """
     _units = ('kg', 'lb', 'g', 'tonne', 'ton', 'oz')
     _si_units = ('kg', 'g', 'tonne')
     _ip_units = ('lb', 'ton')

--- a/ladybug/datatype/mass.py
+++ b/ladybug/datatype/mass.py
@@ -7,18 +7,6 @@ from .base import DataTypeBase
 
 class Mass(DataTypeBase):
     """Mass
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('kg', 'lb', 'g', 'tonne', 'ton', 'oz')
     _si_units = ('kg', 'g', 'tonne')

--- a/ladybug/datatype/mass.py
+++ b/ladybug/datatype/mass.py
@@ -9,39 +9,16 @@ class Mass(DataTypeBase):
     """Mass
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isMass
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('kg', 'lb', 'g', 'tonne', 'ton', 'oz')
     _si_units = ('kg', 'g', 'tonne')

--- a/ladybug/datatype/massflowrate.py
+++ b/ladybug/datatype/massflowrate.py
@@ -7,19 +7,6 @@ from .base import DataTypeBase
 
 class MassFlowRate(DataTypeBase):
     """MassFlowRate
-
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('kg/s', 'lb/s', 'g/s', 'oz/s')
     _si_units = ('kg/s', 'g/s')

--- a/ladybug/datatype/massflowrate.py
+++ b/ladybug/datatype/massflowrate.py
@@ -6,7 +6,44 @@ from .base import DataTypeBase
 
 
 class MassFlowRate(DataTypeBase):
-    """Mass"""
+    """MassFlowRate
+
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isMassFlowRate
+    """
     _units = ('kg/s', 'lb/s', 'g/s', 'oz/s')
     _si_units = ('kg/s', 'g/s')
     _ip_units = ('lb/s', 'oz/s')

--- a/ladybug/datatype/massflowrate.py
+++ b/ladybug/datatype/massflowrate.py
@@ -10,39 +10,16 @@ class MassFlowRate(DataTypeBase):
 
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isMassFlowRate
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('kg/s', 'lb/s', 'g/s', 'oz/s')
     _si_units = ('kg/s', 'g/s')

--- a/ladybug/datatype/power.py
+++ b/ladybug/datatype/power.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class Power(DataTypeBase):
-    """Power"""
+    """Power
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isPower
+    """
     _units = ('W', 'Btu/h', 'kW', 'kBtu/h', 'TR', 'hp')
     _si_units = ('kW', 'W')
     _ip_units = ('Btu/h', 'kBtu/h', 'TR', 'hp')
@@ -72,5 +108,41 @@ class Power(DataTypeBase):
 
 
 class ActivityLevel(Power):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isPower
+    """
     _abbreviation = 'Activity'
     _min = 0

--- a/ladybug/datatype/power.py
+++ b/ladybug/datatype/power.py
@@ -7,18 +7,6 @@ from .base import DataTypeBase
 
 class Power(DataTypeBase):
     """Power
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('W', 'Btu/h', 'kW', 'kBtu/h', 'TR', 'hp')
     _si_units = ('kW', 'W')
@@ -85,18 +73,5 @@ class Power(DataTypeBase):
 
 
 class ActivityLevel(Power):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'Activity'
     _min = 0

--- a/ladybug/datatype/power.py
+++ b/ladybug/datatype/power.py
@@ -9,39 +9,16 @@ class Power(DataTypeBase):
     """Power
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isPower
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('W', 'Btu/h', 'kW', 'kBtu/h', 'TR', 'hp')
     _si_units = ('kW', 'W')
@@ -110,39 +87,16 @@ class Power(DataTypeBase):
 class ActivityLevel(Power):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isPower
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'Activity'
     _min = 0

--- a/ladybug/datatype/pressure.py
+++ b/ladybug/datatype/pressure.py
@@ -9,39 +9,16 @@ class Pressure(DataTypeBase):
     """Pressure
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isPressure
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('Pa', 'inHg', 'atm', 'bar', 'Torr', 'psi', 'inH2O')
     _si_units = ('Pa', 'bar')
@@ -112,39 +89,16 @@ class Pressure(DataTypeBase):
 class AtmosphericStationPressure(Pressure):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isPressure
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _min = 0
     _abbreviation = 'Patm'

--- a/ladybug/datatype/pressure.py
+++ b/ladybug/datatype/pressure.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class Pressure(DataTypeBase):
-    """Pressure"""
+    """Pressure
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isPressure
+    """
     _units = ('Pa', 'inHg', 'atm', 'bar', 'Torr', 'psi', 'inH2O')
     _si_units = ('Pa', 'bar')
     _ip_units = ('inHg', 'psi', 'inH2O')
@@ -74,5 +110,41 @@ class Pressure(DataTypeBase):
 
 
 class AtmosphericStationPressure(Pressure):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isPressure
+    """
     _min = 0
     _abbreviation = 'Patm'

--- a/ladybug/datatype/pressure.py
+++ b/ladybug/datatype/pressure.py
@@ -7,18 +7,6 @@ from .base import DataTypeBase
 
 class Pressure(DataTypeBase):
     """Pressure
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('Pa', 'inHg', 'atm', 'bar', 'Torr', 'psi', 'inH2O')
     _si_units = ('Pa', 'bar')
@@ -87,18 +75,5 @@ class Pressure(DataTypeBase):
 
 
 class AtmosphericStationPressure(Pressure):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _min = 0
     _abbreviation = 'Patm'

--- a/ladybug/datatype/rvalue.py
+++ b/ladybug/datatype/rvalue.py
@@ -7,18 +7,6 @@ from .base import DataTypeBase
 
 class RValue(DataTypeBase):
     """R Value
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('m2-K/W', 'h-ft2-F/Btu', 'clo')
     _si_units = ('m2-K/W', 'clo')
@@ -63,18 +51,5 @@ class RValue(DataTypeBase):
 
 
 class ClothingInsulation(RValue):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'Rclo'
     _unit_descr = {0: 'No Clothing', 0.5: 'T-shirt + Shorts', 1: '3-piece Suit'}

--- a/ladybug/datatype/rvalue.py
+++ b/ladybug/datatype/rvalue.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class RValue(DataTypeBase):
-    """R Value"""
+    """R Value
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isRValue
+    """
     _units = ('m2-K/W', 'h-ft2-F/Btu', 'clo')
     _si_units = ('m2-K/W', 'clo')
     _ip_units = ('h-ft2-F/Btu', 'clo')
@@ -50,5 +86,41 @@ class RValue(DataTypeBase):
 
 
 class ClothingInsulation(RValue):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isRValue
+    """
     _abbreviation = 'Rclo'
     _unit_descr = {0: 'No Clothing', 0.5: 'T-shirt + Shorts', 1: '3-piece Suit'}

--- a/ladybug/datatype/rvalue.py
+++ b/ladybug/datatype/rvalue.py
@@ -9,39 +9,16 @@ class RValue(DataTypeBase):
     """R Value
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isRValue
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('m2-K/W', 'h-ft2-F/Btu', 'clo')
     _si_units = ('m2-K/W', 'clo')
@@ -88,39 +65,16 @@ class RValue(DataTypeBase):
 class ClothingInsulation(RValue):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isRValue
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'Rclo'
     _unit_descr = {0: 'No Clothing', 0.5: 'T-shirt + Shorts', 1: '3-piece Suit'}

--- a/ladybug/datatype/specificenergy.py
+++ b/ladybug/datatype/specificenergy.py
@@ -7,18 +7,6 @@ from .base import DataTypeBase
 
 class SpecificEnergy(DataTypeBase):
     """Energy
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('kWh/kg', 'kBtu/lb', 'Wh/kg', 'Btu/lb', 'J/kg', 'kJ/kg')
     _si_units = ('kWh/kg', 'Wh/kg', 'J/kg', 'kJ/kg')
@@ -86,18 +74,5 @@ class SpecificEnergy(DataTypeBase):
 
 
 class Enthalpy(SpecificEnergy):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'Enth'
     _min = 0

--- a/ladybug/datatype/specificenergy.py
+++ b/ladybug/datatype/specificenergy.py
@@ -9,39 +9,16 @@ class SpecificEnergy(DataTypeBase):
     """Energy
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isSpecificEnergy
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('kWh/kg', 'kBtu/lb', 'Wh/kg', 'Btu/lb', 'J/kg', 'kJ/kg')
     _si_units = ('kWh/kg', 'Wh/kg', 'J/kg', 'kJ/kg')
@@ -111,39 +88,16 @@ class SpecificEnergy(DataTypeBase):
 class Enthalpy(SpecificEnergy):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isSpecificEnergy
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'Enth'
     _min = 0

--- a/ladybug/datatype/specificenergy.py
+++ b/ladybug/datatype/specificenergy.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class SpecificEnergy(DataTypeBase):
-    """Energy"""
+    """Energy
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isSpecificEnergy
+    """
     _units = ('kWh/kg', 'kBtu/lb', 'Wh/kg', 'Btu/lb', 'J/kg', 'kJ/kg')
     _si_units = ('kWh/kg', 'Wh/kg', 'J/kg', 'kJ/kg')
     _ip_units = ('Btu/lb', 'kBtu/lb')
@@ -73,5 +109,41 @@ class SpecificEnergy(DataTypeBase):
 
 
 class Enthalpy(SpecificEnergy):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isSpecificEnergy
+    """
     _abbreviation = 'Enth'
     _min = 0

--- a/ladybug/datatype/speed.py
+++ b/ladybug/datatype/speed.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class Speed(DataTypeBase):
-    """Speed"""
+    """Speed
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isSpeed
+    """
     _units = ('m/s', 'mph', 'km/h', 'knot', 'ft/s')
     _si_units = ('m/s', 'km/h')
     _ip_units = ('mph', 'ft/s')
@@ -62,8 +98,80 @@ class Speed(DataTypeBase):
 
 
 class WindSpeed(Speed):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isSpeed
+    """
     _abbreviation = 'WS'
 
 
 class AirSpeed(Speed):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isSpeed
+    """
     _abbreviation = 'vair'

--- a/ladybug/datatype/speed.py
+++ b/ladybug/datatype/speed.py
@@ -7,18 +7,6 @@ from .base import DataTypeBase
 
 class Speed(DataTypeBase):
     """Speed
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('m/s', 'mph', 'km/h', 'knot', 'ft/s')
     _si_units = ('m/s', 'km/h')
@@ -75,34 +63,8 @@ class Speed(DataTypeBase):
 
 
 class WindSpeed(Speed):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'WS'
 
 
 class AirSpeed(Speed):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'vair'

--- a/ladybug/datatype/speed.py
+++ b/ladybug/datatype/speed.py
@@ -9,39 +9,16 @@ class Speed(DataTypeBase):
     """Speed
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isSpeed
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('m/s', 'mph', 'km/h', 'knot', 'ft/s')
     _si_units = ('m/s', 'km/h')
@@ -100,39 +77,16 @@ class Speed(DataTypeBase):
 class WindSpeed(Speed):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isSpeed
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'WS'
 
@@ -140,38 +94,15 @@ class WindSpeed(Speed):
 class AirSpeed(Speed):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isSpeed
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'vair'

--- a/ladybug/datatype/temperature.py
+++ b/ladybug/datatype/temperature.py
@@ -7,18 +7,6 @@ from .base import DataTypeBase
 
 class Temperature(DataTypeBase):
     """Temperature
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('C', 'F', 'K')
     _si_units = ('C', 'K')
@@ -63,204 +51,48 @@ class Temperature(DataTypeBase):
 
 
 class DryBulbTemperature(Temperature):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'DBT'
 
 
 class DewPointTemperature(Temperature):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'DPT'
 
 
 class WetBulbTemperature(Temperature):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'WBT'
 
 
 class SkyTemperature(Temperature):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'Tsky'
 
 
 class GroundTemperature(Temperature):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'Tground'
 
 
 class AirTemperature(Temperature):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'Tair'
 
 
 class RadiantTemperature(Temperature):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'Trad'
 
 
 class OperativeTemperature(Temperature):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'To'
 
 
 class MeanRadiantTemperature(Temperature):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'MRT'
 
 
 class StandardEffectiveTemperature(Temperature):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'SET'
 
 
 class UniversalThermalClimateIndex(Temperature):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'UTCI'
 
 
 class PrevailingOutdoorTemperature(Temperature):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'Tprevail'

--- a/ladybug/datatype/temperature.py
+++ b/ladybug/datatype/temperature.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class Temperature(DataTypeBase):
-    """Temperature"""
+    """Temperature
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperature
+    """
     _units = ('C', 'F', 'K')
     _si_units = ('C', 'K')
     _ip_units = ('F')
@@ -50,48 +86,480 @@ class Temperature(DataTypeBase):
 
 
 class DryBulbTemperature(Temperature):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperature
+    """
     _abbreviation = 'DBT'
 
 
 class DewPointTemperature(Temperature):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperature
+    """
     _abbreviation = 'DPT'
 
 
 class WetBulbTemperature(Temperature):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperature
+    """
     _abbreviation = 'WBT'
 
 
 class SkyTemperature(Temperature):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperature
+    """
     _abbreviation = 'Tsky'
 
 
 class GroundTemperature(Temperature):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperature
+    """
     _abbreviation = 'Tground'
 
 
 class AirTemperature(Temperature):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperature
+    """
     _abbreviation = 'Tair'
 
 
 class RadiantTemperature(Temperature):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperature
+    """
     _abbreviation = 'Trad'
 
 
 class OperativeTemperature(Temperature):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperature
+    """
     _abbreviation = 'To'
 
 
 class MeanRadiantTemperature(Temperature):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperature
+    """
     _abbreviation = 'MRT'
 
 
 class StandardEffectiveTemperature(Temperature):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperature
+    """
     _abbreviation = 'SET'
 
 
 class UniversalThermalClimateIndex(Temperature):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperature
+    """
     _abbreviation = 'UTCI'
 
 
 class PrevailingOutdoorTemperature(Temperature):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperature
+    """
     _abbreviation = 'Tprevail'

--- a/ladybug/datatype/temperature.py
+++ b/ladybug/datatype/temperature.py
@@ -9,39 +9,16 @@ class Temperature(DataTypeBase):
     """Temperature
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperature
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('C', 'F', 'K')
     _si_units = ('C', 'K')
@@ -88,39 +65,16 @@ class Temperature(DataTypeBase):
 class DryBulbTemperature(Temperature):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperature
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'DBT'
 
@@ -128,39 +82,16 @@ class DryBulbTemperature(Temperature):
 class DewPointTemperature(Temperature):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperature
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'DPT'
 
@@ -168,39 +99,16 @@ class DewPointTemperature(Temperature):
 class WetBulbTemperature(Temperature):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperature
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'WBT'
 
@@ -208,39 +116,16 @@ class WetBulbTemperature(Temperature):
 class SkyTemperature(Temperature):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperature
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'Tsky'
 
@@ -248,39 +133,16 @@ class SkyTemperature(Temperature):
 class GroundTemperature(Temperature):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperature
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'Tground'
 
@@ -288,39 +150,16 @@ class GroundTemperature(Temperature):
 class AirTemperature(Temperature):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperature
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'Tair'
 
@@ -328,39 +167,16 @@ class AirTemperature(Temperature):
 class RadiantTemperature(Temperature):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperature
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'Trad'
 
@@ -368,39 +184,16 @@ class RadiantTemperature(Temperature):
 class OperativeTemperature(Temperature):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperature
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'To'
 
@@ -408,39 +201,16 @@ class OperativeTemperature(Temperature):
 class MeanRadiantTemperature(Temperature):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperature
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'MRT'
 
@@ -448,39 +218,16 @@ class MeanRadiantTemperature(Temperature):
 class StandardEffectiveTemperature(Temperature):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperature
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'SET'
 
@@ -488,39 +235,16 @@ class StandardEffectiveTemperature(Temperature):
 class UniversalThermalClimateIndex(Temperature):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperature
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'UTCI'
 
@@ -528,38 +252,15 @@ class UniversalThermalClimateIndex(Temperature):
 class PrevailingOutdoorTemperature(Temperature):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperature
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'Tprevail'

--- a/ladybug/datatype/temperaturedelta.py
+++ b/ladybug/datatype/temperaturedelta.py
@@ -7,18 +7,6 @@ from .base import DataTypeBase
 
 class TemperatureDelta(DataTypeBase):
     """TemperatureDelta
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('C', 'F', 'K')
     _si_units = ('C', 'K')
@@ -62,51 +50,12 @@ class TemperatureDelta(DataTypeBase):
 
 
 class AirTemperatureDelta(TemperatureDelta):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'DeltaTair'
 
 
 class RadiantTemperatureDelta(TemperatureDelta):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'DeltaTrad'
 
 
 class OperativeTemperatureDelta(TemperatureDelta):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'DeltaTo'

--- a/ladybug/datatype/temperaturedelta.py
+++ b/ladybug/datatype/temperaturedelta.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class TemperatureDelta(DataTypeBase):
-    """Temperature"""
+    """TemperatureDelta
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperatureDelta
+    """
     _units = ('C', 'F', 'K')
     _si_units = ('C', 'K')
     _ip_units = ('F')
@@ -49,12 +85,120 @@ class TemperatureDelta(DataTypeBase):
 
 
 class AirTemperatureDelta(TemperatureDelta):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperatureDelta
+    """
     _abbreviation = 'DeltaTair'
 
 
 class RadiantTemperatureDelta(TemperatureDelta):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperatureDelta
+    """
     _abbreviation = 'DeltaTrad'
 
 
 class OperativeTemperatureDelta(TemperatureDelta):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperatureDelta
+    """
     _abbreviation = 'DeltaTo'

--- a/ladybug/datatype/temperaturedelta.py
+++ b/ladybug/datatype/temperaturedelta.py
@@ -9,39 +9,16 @@ class TemperatureDelta(DataTypeBase):
     """TemperatureDelta
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperatureDelta
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('C', 'F', 'K')
     _si_units = ('C', 'K')
@@ -87,39 +64,16 @@ class TemperatureDelta(DataTypeBase):
 class AirTemperatureDelta(TemperatureDelta):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperatureDelta
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'DeltaTair'
 
@@ -127,39 +81,16 @@ class AirTemperatureDelta(TemperatureDelta):
 class RadiantTemperatureDelta(TemperatureDelta):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperatureDelta
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'DeltaTrad'
 
@@ -167,38 +98,15 @@ class RadiantTemperatureDelta(TemperatureDelta):
 class OperativeTemperatureDelta(TemperatureDelta):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperatureDelta
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'DeltaTo'

--- a/ladybug/datatype/temperaturetime.py
+++ b/ladybug/datatype/temperaturetime.py
@@ -9,39 +9,16 @@ class TemperatureTime(DataTypeBase):
     """Temperature-Time
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperatureTime
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('degC-days', 'degF-days', 'degC-hours', 'degF-hours')
     _si_units = ('degC-days', 'degC-hours')
@@ -97,39 +74,16 @@ class TemperatureTime(DataTypeBase):
 class CoolingDegreeTime(TemperatureTime):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperatureTime
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'coolTime'
 
@@ -137,38 +91,15 @@ class CoolingDegreeTime(TemperatureTime):
 class HeatingDegreeTime(TemperatureTime):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isTemperatureTime
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'heatTime'

--- a/ladybug/datatype/temperaturetime.py
+++ b/ladybug/datatype/temperaturetime.py
@@ -7,18 +7,6 @@ from .base import DataTypeBase
 
 class TemperatureTime(DataTypeBase):
     """Temperature-Time
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('degC-days', 'degF-days', 'degC-hours', 'degF-hours')
     _si_units = ('degC-days', 'degC-hours')
@@ -72,34 +60,8 @@ class TemperatureTime(DataTypeBase):
 
 
 class CoolingDegreeTime(TemperatureTime):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'coolTime'
 
 
 class HeatingDegreeTime(TemperatureTime):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'heatTime'

--- a/ladybug/datatype/temperaturetime.py
+++ b/ladybug/datatype/temperaturetime.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class TemperatureTime(DataTypeBase):
-    """Temperature-Time"""
+    """Temperature-Time
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperatureTime
+    """
     _units = ('degC-days', 'degF-days', 'degC-hours', 'degF-hours')
     _si_units = ('degC-days', 'degC-hours')
     _ip_units = ('degF-days', 'degF-hours')
@@ -59,8 +95,80 @@ class TemperatureTime(DataTypeBase):
 
 
 class CoolingDegreeTime(TemperatureTime):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperatureTime
+    """
     _abbreviation = 'coolTime'
 
 
 class HeatingDegreeTime(TemperatureTime):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isTemperatureTime
+    """
     _abbreviation = 'heatTime'

--- a/ladybug/datatype/thermalcondition.py
+++ b/ladybug/datatype/thermalcondition.py
@@ -7,18 +7,6 @@ from .base import DataTypeBase
 
 class ThermalCondition(DataTypeBase):
     """Thermal Condition
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('condition', 'PMV')
     _si_units = ('condition', 'PMV')
@@ -53,19 +41,6 @@ class ThermalCondition(DataTypeBase):
 
 
 class PredictedMeanVote(ThermalCondition):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _min = float('-inf')
     _max = float('+inf')
     _abbreviation = 'PMV'
@@ -74,19 +49,6 @@ class PredictedMeanVote(ThermalCondition):
 
 
 class ThermalComfort(ThermalCondition):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _min = 0
     _max = 1
     _abbreviation = 'TC'
@@ -94,19 +56,6 @@ class ThermalComfort(ThermalCondition):
 
 
 class DiscomfortReason(ThermalCondition):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _min = -2
     _max = 2
     _abbreviation = 'RDiscomf'
@@ -115,19 +64,6 @@ class DiscomfortReason(ThermalCondition):
 
 
 class ThermalConditionFivePoint(ThermalCondition):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _min = -2
     _max = 2
     _abbreviation = 'Tcond-5'
@@ -136,19 +72,6 @@ class ThermalConditionFivePoint(ThermalCondition):
 
 
 class ThermalConditionSevenPoint(ThermalCondition):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _min = -3
     _max = 3
     _abbreviation = 'Tcond-7'
@@ -158,19 +81,6 @@ class ThermalConditionSevenPoint(ThermalCondition):
 
 
 class ThermalConditionNinePoint(ThermalCondition):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _min = -4
     _max = 4
     _abbreviation = 'Tcond-9'
@@ -181,19 +91,6 @@ class ThermalConditionNinePoint(ThermalCondition):
 
 
 class ThermalConditionElevenPoint(ThermalCondition):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _min = -5
     _max = 5
     _abbreviation = 'Tcond-11'
@@ -204,19 +101,6 @@ class ThermalConditionElevenPoint(ThermalCondition):
 
 
 class UTCICategory(ThermalCondition):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _min = 0
     _max = 9
     _abbreviation = 'UTCIcond'

--- a/ladybug/datatype/thermalcondition.py
+++ b/ladybug/datatype/thermalcondition.py
@@ -9,39 +9,16 @@ class ThermalCondition(DataTypeBase):
     """Thermal Condition
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isThermalCondition
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('condition', 'PMV')
     _si_units = ('condition', 'PMV')
@@ -78,39 +55,16 @@ class ThermalCondition(DataTypeBase):
 class PredictedMeanVote(ThermalCondition):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isThermalCondition
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _min = float('-inf')
     _max = float('+inf')
@@ -122,39 +76,16 @@ class PredictedMeanVote(ThermalCondition):
 class ThermalComfort(ThermalCondition):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isThermalCondition
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _min = 0
     _max = 1
@@ -165,39 +96,16 @@ class ThermalComfort(ThermalCondition):
 class DiscomfortReason(ThermalCondition):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isThermalCondition
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _min = -2
     _max = 2
@@ -209,39 +117,16 @@ class DiscomfortReason(ThermalCondition):
 class ThermalConditionFivePoint(ThermalCondition):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isThermalCondition
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _min = -2
     _max = 2
@@ -253,39 +138,16 @@ class ThermalConditionFivePoint(ThermalCondition):
 class ThermalConditionSevenPoint(ThermalCondition):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isThermalCondition
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _min = -3
     _max = 3
@@ -298,39 +160,16 @@ class ThermalConditionSevenPoint(ThermalCondition):
 class ThermalConditionNinePoint(ThermalCondition):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isThermalCondition
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _min = -4
     _max = 4
@@ -344,39 +183,16 @@ class ThermalConditionNinePoint(ThermalCondition):
 class ThermalConditionElevenPoint(ThermalCondition):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isThermalCondition
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _min = -5
     _max = 5
@@ -390,39 +206,16 @@ class ThermalConditionElevenPoint(ThermalCondition):
 class UTCICategory(ThermalCondition):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isThermalCondition
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _min = 0
     _max = 9

--- a/ladybug/datatype/thermalcondition.py
+++ b/ladybug/datatype/thermalcondition.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class ThermalCondition(DataTypeBase):
-    """Thermal Condition"""
+    """Thermal Condition
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isThermalCondition
+    """
     _units = ('condition', 'PMV')
     _si_units = ('condition', 'PMV')
     _ip_units = ('condition', 'PMV')
@@ -40,6 +76,42 @@ class ThermalCondition(DataTypeBase):
 
 
 class PredictedMeanVote(ThermalCondition):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isThermalCondition
+    """
     _min = float('-inf')
     _max = float('+inf')
     _abbreviation = 'PMV'
@@ -48,6 +120,42 @@ class PredictedMeanVote(ThermalCondition):
 
 
 class ThermalComfort(ThermalCondition):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isThermalCondition
+    """
     _min = 0
     _max = 1
     _abbreviation = 'TC'
@@ -55,6 +163,42 @@ class ThermalComfort(ThermalCondition):
 
 
 class DiscomfortReason(ThermalCondition):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isThermalCondition
+    """
     _min = -2
     _max = 2
     _abbreviation = 'RDiscomf'
@@ -63,6 +207,42 @@ class DiscomfortReason(ThermalCondition):
 
 
 class ThermalConditionFivePoint(ThermalCondition):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isThermalCondition
+    """
     _min = -2
     _max = 2
     _abbreviation = 'Tcond-5'
@@ -71,6 +251,42 @@ class ThermalConditionFivePoint(ThermalCondition):
 
 
 class ThermalConditionSevenPoint(ThermalCondition):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isThermalCondition
+    """
     _min = -3
     _max = 3
     _abbreviation = 'Tcond-7'
@@ -80,6 +296,42 @@ class ThermalConditionSevenPoint(ThermalCondition):
 
 
 class ThermalConditionNinePoint(ThermalCondition):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isThermalCondition
+    """
     _min = -4
     _max = 4
     _abbreviation = 'Tcond-9'
@@ -90,6 +342,42 @@ class ThermalConditionNinePoint(ThermalCondition):
 
 
 class ThermalConditionElevenPoint(ThermalCondition):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isThermalCondition
+    """
     _min = -5
     _max = 5
     _abbreviation = 'Tcond-11'
@@ -100,6 +388,42 @@ class ThermalConditionElevenPoint(ThermalCondition):
 
 
 class UTCICategory(ThermalCondition):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isThermalCondition
+    """
     _min = 0
     _max = 9
     _abbreviation = 'UTCIcond'

--- a/ladybug/datatype/uvalue.py
+++ b/ladybug/datatype/uvalue.py
@@ -9,39 +9,16 @@ class UValue(DataTypeBase):
     """U Value
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isUValue
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('W/m2-K', 'Btu/h-ft2-F')
     _si_units = ('W/m2-K')
@@ -82,39 +59,16 @@ class UValue(DataTypeBase):
 class ConvectionCoefficient(UValue):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isUValue
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'hc'
 
@@ -122,38 +76,15 @@ class ConvectionCoefficient(UValue):
 class RadiantCoefficient(UValue):
     """
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isUValue
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _abbreviation = 'hr'

--- a/ladybug/datatype/uvalue.py
+++ b/ladybug/datatype/uvalue.py
@@ -7,18 +7,6 @@ from .base import DataTypeBase
 
 class UValue(DataTypeBase):
     """U Value
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('W/m2-K', 'Btu/h-ft2-F')
     _si_units = ('W/m2-K')
@@ -57,34 +45,8 @@ class UValue(DataTypeBase):
 
 
 class ConvectionCoefficient(UValue):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'hc'
 
 
 class RadiantCoefficient(UValue):
-    """
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
-    """
     _abbreviation = 'hr'

--- a/ladybug/datatype/uvalue.py
+++ b/ladybug/datatype/uvalue.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class UValue(DataTypeBase):
-    """U Value"""
+    """U Value
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isUValue
+    """
     _units = ('W/m2-K', 'Btu/h-ft2-F')
     _si_units = ('W/m2-K')
     _ip_units = ('Btu/h-ft2-F')
@@ -44,8 +80,80 @@ class UValue(DataTypeBase):
 
 
 class ConvectionCoefficient(UValue):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isUValue
+    """
     _abbreviation = 'hc'
 
 
 class RadiantCoefficient(UValue):
+    """
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isUValue
+    """
     _abbreviation = 'hr'

--- a/ladybug/datatype/volume.py
+++ b/ladybug/datatype/volume.py
@@ -7,18 +7,6 @@ from .base import DataTypeBase
 
 class Volume(DataTypeBase):
     """Volume
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('m3', 'ft3', 'mm3', 'in3', 'km3', 'mi3', 'L', 'mL', 'gal', 'fl oz')
     _si_units = ('m3', 'mm3', 'km3', 'L', 'mL')

--- a/ladybug/datatype/volume.py
+++ b/ladybug/datatype/volume.py
@@ -9,39 +9,16 @@ class Volume(DataTypeBase):
     """Volume
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isVolume
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('m3', 'ft3', 'mm3', 'in3', 'km3', 'mi3', 'L', 'mL', 'gal', 'fl oz')
     _si_units = ('m3', 'mm3', 'km3', 'L', 'mL')

--- a/ladybug/datatype/volume.py
+++ b/ladybug/datatype/volume.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class Volume(DataTypeBase):
-    """Volume"""
+    """Volume
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isVolume
+    """
     _units = ('m3', 'ft3', 'mm3', 'in3', 'km3', 'mi3', 'L', 'mL', 'gal', 'fl oz')
     _si_units = ('m3', 'mm3', 'km3', 'L', 'mL')
     _ip_units = ('ft3', 'in3', 'mi3', 'gal', 'fl oz')

--- a/ladybug/datatype/volumeflowrate.py
+++ b/ladybug/datatype/volumeflowrate.py
@@ -9,39 +9,16 @@ class VolumeFlowRate(DataTypeBase):
     """Volume Flow Rate
 
     Properties:
-        *   name: The full name of the data type as a string.
-        *   units: A list of all accetpable units of the data type as abbreviated text.
-            The first item of the list should be the standard SI unit.
-            The second item of the list should be the stadard IP unit (if it exists).
-            The rest of the list can be any other acceptable units.
-            (eg. [C, F, K])
-        *   si_units: A list of acceptable SI units.
-        *   ip_units: A list of acceptable IP units.
-        *   min: Lower limit for the data type, values below which should be physically
-            or mathematically impossible. (Default: -inf)
-        *   max: Upper limit for the data type, values above which should be physically
-            or mathematically impossible. (Default: +inf)
-        *   abbreviation: An optional abbreviation for the data type as text.
-            (eg. 'UTCI' for Universal Thermal Climate Index).
-            This can also be a letter that represents the data type in a formula.
-            (eg. 'A' for Area; 'P' for Pressure)
-        *   unit_descr: An optional dictionary describing categories that the numerical
-            values of the units relate to. For example:
-            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
-            {0: 'False', 1: 'True'}
-        *   point_in_time: Boolean to note whether the data type represents conditions
-            at a single instant in time (True) as opposed to being an average or
-            accumulation over time (False) when it is found in hourly lists of data.
-            (True Examples: Temperature, WindSpeed)
-            (False Examples: Energy, Radiation, Illuminance)
-        *   cumulative: Boolean to tell whether the data type can be cumulative when it
-            is represented over time (True) or it can only be averaged over time
-            to be meaningful (False). Note that cumulative cannot be True
-            when point_in_time is also True.
-            (False Examples: Temperature, Irradiance, Illuminance)
-            (True Examples: Energy, Radiation)
-        *   isDataType
-        *   isFlowRate
+        *   name
+        *   units
+        *   si_units
+        *   ip_units
+        *   min
+        *   max
+        *   abbreviation
+        *   unit_descr
+        *   point_in_time
+        *   cumulative
     """
     _units = ('m3/s', 'ft3/s', 'L/s', 'cfm', 'gpm', 'mL/s', 'fl oz/s')
     _si_units = ('m3/s', 'L/s', 'mL/s')

--- a/ladybug/datatype/volumeflowrate.py
+++ b/ladybug/datatype/volumeflowrate.py
@@ -7,18 +7,6 @@ from .base import DataTypeBase
 
 class VolumeFlowRate(DataTypeBase):
     """Volume Flow Rate
-
-    Properties:
-        *   name
-        *   units
-        *   si_units
-        *   ip_units
-        *   min
-        *   max
-        *   abbreviation
-        *   unit_descr
-        *   point_in_time
-        *   cumulative
     """
     _units = ('m3/s', 'ft3/s', 'L/s', 'cfm', 'gpm', 'mL/s', 'fl oz/s')
     _si_units = ('m3/s', 'L/s', 'mL/s')

--- a/ladybug/datatype/volumeflowrate.py
+++ b/ladybug/datatype/volumeflowrate.py
@@ -6,7 +6,43 @@ from .base import DataTypeBase
 
 
 class VolumeFlowRate(DataTypeBase):
-    """Volume Flow Rate"""
+    """Volume Flow Rate
+
+    Properties:
+        *   name: The full name of the data type as a string.
+        *   units: A list of all accetpable units of the data type as abbreviated text.
+            The first item of the list should be the standard SI unit.
+            The second item of the list should be the stadard IP unit (if it exists).
+            The rest of the list can be any other acceptable units.
+            (eg. [C, F, K])
+        *   si_units: A list of acceptable SI units.
+        *   ip_units: A list of acceptable IP units.
+        *   min: Lower limit for the data type, values below which should be physically
+            or mathematically impossible. (Default: -inf)
+        *   max: Upper limit for the data type, values above which should be physically
+            or mathematically impossible. (Default: +inf)
+        *   abbreviation: An optional abbreviation for the data type as text.
+            (eg. 'UTCI' for Universal Thermal Climate Index).
+            This can also be a letter that represents the data type in a formula.
+            (eg. 'A' for Area; 'P' for Pressure)
+        *   unit_descr: An optional dictionary describing categories that the numerical
+            values of the units relate to. For example:
+            {-1: 'Cold', 0: 'Neutral', +1: 'Hot'}
+            {0: 'False', 1: 'True'}
+        *   point_in_time: Boolean to note whether the data type represents conditions
+            at a single instant in time (True) as opposed to being an average or
+            accumulation over time (False) when it is found in hourly lists of data.
+            (True Examples: Temperature, WindSpeed)
+            (False Examples: Energy, Radiation, Illuminance)
+        *   cumulative: Boolean to tell whether the data type can be cumulative when it
+            is represented over time (True) or it can only be averaged over time
+            to be meaningful (False). Note that cumulative cannot be True
+            when point_in_time is also True.
+            (False Examples: Temperature, Irradiance, Illuminance)
+            (True Examples: Energy, Radiation)
+        *   isDataType
+        *   isFlowRate
+    """
     _units = ('m3/s', 'ft3/s', 'L/s', 'cfm', 'gpm', 'mL/s', 'fl oz/s')
     _si_units = ('m3/s', 'L/s', 'mL/s')
     _ip_units = ('ft3/s', 'cfm', 'gpm', 'fl oz/s')

--- a/ladybug/designday.py
+++ b/ladybug/designday.py
@@ -51,9 +51,7 @@ class DDY(object):
         * location
         * name
         * sky_condition
-
-wind_condition
-Get or set the wind conditions.
+        * wind_condition
     """
     _location_format = re.compile(
         r"(Site:Location,(.|\n)*?((;\s*!)|(;\s*\n)|(;\n)))")
@@ -76,11 +74,11 @@ Get or set the wind conditions.
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
             {
-            "location": ladybug Location schema,
-            "design_days": [] // list of ladybug DesignDay schemas
+            "location": l  # ladybug Location schema,
+            "design_days": d  # list of ladybug DesignDay schemas
             }
         """
         required_keys = ('location', 'design_days')
@@ -326,16 +324,16 @@ class DesignDay(object):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
             {
-            "name": string,
-            "day_type": string,
-            "location": ladybug Location schema,
-            "dry_bulb_condition": ladybug DryBulbCondition schema,
-            "humidity_condition": ladybug HumidityCondition schema,
-            "wind_condition": ladybug WindCondition schema,
-            "sky_condition": ladybug SkyCondition schema
+            "name": s  # string,
+            "day_type": d  # string,
+            "location": l  # ladybug Location schema,
+            "dry_bulb_condition": b  # ladybug DryBulbCondition schema,
+            "humidity_condition": h  # ladybug HumidityCondition schema,
+            "wind_condition": w  # ladybug WindCondition schema,
+            "sky_condition": s  # ladybug SkyCondition schema
             }
         """
         required_keys = ('name', 'day_type', 'location', 'dry_bulb_condition',
@@ -821,13 +819,13 @@ class DryBulbCondition(object):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
             {
-            "dry_bulb_max": float,
-            "dry_bulb_range": float,
-            "modifier_type": string,
-            "modifier_schedule": string
+            "dry_bulb_max": m  # float,
+            "dry_bulb_range": r  # float,
+            "modifier_type": t  # string,
+            "modifier_schedule": s  # string
             }
         """
         # Check required and optional keys
@@ -941,14 +939,14 @@ class HumidityCondition(object):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
             {
-            "hum_type": string,
-            "hum_value": float,
-            "barometric_pressure": float,
-            "schedule": string,
-            "wet_bulb_range": string
+            "hum_type": t  # string,
+            "hum_value": v  # float,
+            "barometric_pressure": p  # float,
+            "schedule": s  # string,
+            "wet_bulb_range": r  # string
             }
         """
         # Check required and optional keys
@@ -1099,13 +1097,13 @@ class WindCondition(object):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
             {
-            "wind_speed": float,
-            "wind_direction": float,
-            "rain": bool,
-            "snow_on_ground": bool
+            "wind_speed": s  # float,
+            "wind_direction": d  # float,
+            "rain": False  # bool,
+            "snow_on_ground": False  # bool
             }
         """
         # Check required and optional keys
@@ -1241,13 +1239,13 @@ class SkyCondition(object):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
             {
-            "solar_model": string,
-            "month": int,
-            "day_of_month": int,
-            "daylight_savings_indicator": string // "Yes" or "No"
+            "solar_model": s  # string,
+            "month": m  # int,
+            "day_of_month": d  # int,
+            "daylight_savings_indicator": ds  # string // "Yes" or "No"
             }
         """
         # Check required and optional keys
@@ -1393,14 +1391,14 @@ class OriginalClearSkyCondition(SkyCondition):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
             {
-            "solar_model": string,
-            "month": int,
-            "day_of_month": int,
-            "clearness": float,
-            "daylight_savings_indicator": string // "Yes" or "No"
+            "solar_model": s  # string,
+            "month": 1  # int,
+            "day_of_month": 1  # int,
+            "clearness": c  # float,
+            "daylight_savings_indicator": "No"  # string // "Yes" or "No"
             }
         """
         # Check required and optional keys
@@ -1506,15 +1504,15 @@ class RevisedClearSkyCondition(SkyCondition):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
             {
-            "solar_model": string,
-            "month": int,
-            "day_of_month": int,
-            "tau_b": float,
-            "tau_d": float,
-            "daylight_savings_indicator": string // "Yes" or "No"
+            "solar_model": s  # string,
+            "month": 1  # int,
+            "day_of_month": 1  # int,
+            "tau_b": tb  # float,
+            "tau_d": td  # float,
+            "daylight_savings_indicator": "No"  #string // "Yes" or "No"
             }
         """
         # Check required and optional keys

--- a/ladybug/designday.py
+++ b/ladybug/designday.py
@@ -77,8 +77,8 @@ class DDY(object):
         .. code-block:: python
 
             {
-            "location": l  # ladybug Location schema,
-            "design_days": d  # list of ladybug DesignDay schemas
+            "location": {}  # ladybug Location schema,
+            "design_days": []  # list of ladybug DesignDay schemas
             }
         """
         required_keys = ('location', 'design_days')
@@ -327,13 +327,13 @@ class DesignDay(object):
         .. code-block:: python
 
             {
-            "name": s  # string,
-            "day_type": d  # string,
-            "location": l  # ladybug Location schema,
-            "dry_bulb_condition": b  # ladybug DryBulbCondition schema,
-            "humidity_condition": h  # ladybug HumidityCondition schema,
-            "wind_condition": w  # ladybug WindCondition schema,
-            "sky_condition": s  # ladybug SkyCondition schema
+            "name": "",  # string
+            "day_type": "",  # string
+            "location": {},  # ladybug Location schema
+            "dry_bulb_condition": {},  # ladybug DryBulbCondition schema
+            "humidity_condition": {},  # ladybug HumidityCondition schema
+            "wind_condition": {},  # ladybug WindCondition schema
+            "sky_condition": {}  # ladybug SkyCondition schema
             }
         """
         required_keys = ('name', 'day_type', 'location', 'dry_bulb_condition',
@@ -822,10 +822,10 @@ class DryBulbCondition(object):
         .. code-block:: python
 
             {
-            "dry_bulb_max": m  # float,
-            "dry_bulb_range": r  # float,
-            "modifier_type": t  # string,
-            "modifier_schedule": s  # string
+            "dry_bulb_max": 0.0  # float,
+            "dry_bulb_range": 0.0  # float,
+            "modifier_type": ""  # string,
+            "modifier_schedule": ""  # string
             }
         """
         # Check required and optional keys
@@ -942,11 +942,11 @@ class HumidityCondition(object):
         .. code-block:: python
 
             {
-            "hum_type": t  # string,
-            "hum_value": v  # float,
-            "barometric_pressure": p  # float,
-            "schedule": s  # string,
-            "wet_bulb_range": r  # string
+            "hum_type": ""  # string,
+            "hum_value": 0.0  # float,
+            "barometric_pressure": 0.0  # float,
+            "schedule": {}  # string,
+            "wet_bulb_range": ""  # string
             }
         """
         # Check required and optional keys
@@ -1100,8 +1100,8 @@ class WindCondition(object):
         .. code-block:: python
 
             {
-            "wind_speed": s  # float,
-            "wind_direction": d  # float,
+            "wind_speed": 0.0  # float,
+            "wind_direction": 0.0  # float,
             "rain": False  # bool,
             "snow_on_ground": False  # bool
             }
@@ -1242,10 +1242,10 @@ class SkyCondition(object):
         .. code-block:: python
 
             {
-            "solar_model": s  # string,
-            "month": m  # int,
-            "day_of_month": d  # int,
-            "daylight_savings_indicator": ds  # string // "Yes" or "No"
+            "solar_model": ""  # string,
+            "month": 1  # int,
+            "day_of_month": 1  # int,
+            "daylight_savings_indicator": "No"  # string // "Yes" or "No"
             }
         """
         # Check required and optional keys
@@ -1394,10 +1394,10 @@ class OriginalClearSkyCondition(SkyCondition):
         .. code-block:: python
 
             {
-            "solar_model": s  # string,
+            "solar_model": ""  # string,
             "month": 1  # int,
             "day_of_month": 1  # int,
-            "clearness": c  # float,
+            "clearness": 0.0  # float,
             "daylight_savings_indicator": "No"  # string // "Yes" or "No"
             }
         """
@@ -1507,11 +1507,11 @@ class RevisedClearSkyCondition(SkyCondition):
         .. code-block:: python
 
             {
-            "solar_model": s  # string,
+            "solar_model": ""  # string,
             "month": 1  # int,
             "day_of_month": 1  # int,
-            "tau_b": tb  # float,
-            "tau_d": td  # float,
+            "tau_b": 0.0  # float,
+            "tau_d": 0.0  # float,
             "daylight_savings_indicator": "No"  #string // "Yes" or "No"
             }
         """

--- a/ladybug/designday.py
+++ b/ladybug/designday.py
@@ -792,7 +792,7 @@ class DryBulbCondition(object):
     """Represents dry bulb conditions on a design day.
 
     Args:
-       dry_bulb_max: The maximum dry bulb temperature on the design day [C].
+        dry_bulb_max: The maximum dry bulb temperature on the design day [C].
         dry_bulb_range: The difference between mina dn max temperatures on the
             design day [C].
         modifier_type: Text string for the type of modifier used to estimate

--- a/ladybug/designday.py
+++ b/ladybug/designday.py
@@ -792,10 +792,16 @@ class DryBulbCondition(object):
     """Represents dry bulb conditions on a design day.
 
     Args:
-        dry_bulb_max
-        dry_bulb_range
-        modifier_type
-        modifier_schedule
+       dry_bulb_max: The maximum dry bulb temperature on the design day [C].
+        dry_bulb_range: The difference between mina dn max temperatures on the
+            design day [C].
+        modifier_type: Text string for the type of modifier used to estimate
+            temperature at a given timestep. Choose from the following:
+            'DefaultMultipliers', 'MultiplierSchedule', 'DifferenceSchedule',
+            'TemperatureProfileSchedule'. Default: 'DefaultMultipliers'
+        modifier_schedule: Optional text string for the name of the modifier
+            schedule. Should be an empty string unless 'MultiplierSchedule' is
+            selected as the modifier_type.
 
     Properties:
         * dry_bulb_max
@@ -1067,10 +1073,10 @@ class WindCondition(object):
     """Represents wind and rain conditions on the design day.
 
     Args:
-        wind_speed
-        wind_direction
-        rain
-        snow_on_ground
+        wind_speed: Wind speed on the design day [m/s].
+        wind_direction: Wind direction on the design day [degrees]. Default: 0
+        rain: Boolean to indicate rain on the design day. Default: False.
+        snow_on_ground: Boolean to indicate snow on the design day. Default: False.
 
     Properties:
         * wind_speed
@@ -1206,12 +1212,16 @@ class SkyCondition(object):
     """An object representing a sky on the design day.
 
     Args:
-        solar_model
-        month
-        day_of_month
-        daylight_savings_indicator
-        beam_shced
-        diff_sched
+        solar_model: Text for the name of the solar model to use. Choose from the
+            following: 'ASHRAEClearSky', 'ASHRAETau', 'ZhangHuang', 'Schedule'
+        month: Month in which the design day occurs.
+        day_of_month: Day of the month on which the design day occurs.
+        daylight_savings_indicator: Text ('Yes' or 'No'), for whether daylight savings
+            time is active. Default: 'No'
+        beam_shced: Schedule name for beam irradiance. Shoulb be an empty string unless
+            solar_model is 'Schedule'.
+        diff_sched: Schedule name for diffuse irradiance. Shoulb be an empty string
+            unless solar_model is 'Schedule'.
 
     Properties:
         * month
@@ -1358,10 +1368,12 @@ class OriginalClearSkyCondition(SkyCondition):
     """An object representing an original ASHRAE Clear Sky.
 
     Args:
-        month
-        day_of_month
-        clearness
-        daylight_savings_indicator
+        month: Month in which the design day occurs.
+        day_of_month: Day of the month on which the design day occurs.
+        clearness: Value between 0 and 1.2 that will get multiplied by the model's
+            irradinace to correct for factors like elevation.
+        daylight_savings_indicator: Text ('Yes' or 'No'), for whether daylight savings
+            time is active. Default: 'No'
 
     Properties:
         * month
@@ -1465,11 +1477,14 @@ class RevisedClearSkyCondition(SkyCondition):
     """An object representing an ASHRAE Revised Clear Sky (Tau model).
 
     Args:
-        month
-        day_of_month
-        tau_b
-        tau_d
-        daylight_savings_indicator
+        month: Month in which the design day occurs.
+        day_of_month: Day of the month on which the design day occurs.
+        tau_b: Value for the 'beam' term in the Tau model. Typically
+            found in .stat files.
+        tau_d: Value for the 'diffuse' term in the Tau model. Typically
+            found in .stat files.
+        daylight_savings_indicator: Text ('Yes' or 'No'), for whether daylight savings
+            time is active. Default: 'No'
 
     Properties:
         * day_of_month

--- a/ladybug/designday.py
+++ b/ladybug/designday.py
@@ -36,22 +36,9 @@ class DDY(object):
         design_days: A list of the design days in the ddy file.
 
     Properties:
-        * hourly_barometric_pressure
-        * hourly_datetimes
-        * hourly_dew_point
-        * hourly_dry_bulb
-        * hourly_horizontal_infrared
-        * hourly_relative_humidity
-        * hourly_sky_cover
-        * hourly_solar_radiation
-        * hourly_wind_direction
-        * hourly_wind_speed
-        * humidity_condition
-        * isDesignDay
+        * file_locatiom
         * location
-        * name
-        * sky_condition
-        * wind_condition
+        * design_days
     """
     _location_format = re.compile(
         r"(Site:Location,(.|\n)*?((;\s*!)|(;\s*\n)|(;\n)))")
@@ -251,9 +238,20 @@ class DesignDay(object):
         * day_type
         * location
         * dry_bulb_condition
+        * hourly_barometric_pressure
+        * hourly_datetimes
+        * hourly_dew_point
+        * hourly_dry_bulb
+        * hourly_horizontal_infrared
+        * hourly_relative_humidity
+        * hourly_sky_cover
+        * hourly_solar_radiation
+        * hourly_wind_direction
+        * hourly_wind_speed
         * humidity_condition
-        * wind_condition
+        * name
         * sky_condition
+        * wind_condition
     """
     # possible day types
     day_types = ('SummerDesignDay', 'WinterDesignDay', 'Sunday', 'Monday',
@@ -807,7 +805,6 @@ class DryBulbCondition(object):
         * dry_bulb_max
         * dry_bulb_range
         * hourly_values
-        * isDryBulbCondition
         * temp_multipliers
     """
     def __init__(self, dry_bulb_max, dry_bulb_range,
@@ -927,7 +924,6 @@ class HumidityCondition(object):
         * wet_bulb_range
         * hourly_pressure
         * humid_types
-        * isHumidityCondition
     """
     def __init__(self, hum_type, hum_value, barometric_pressure=101325,
                  schedule='', wet_bulb_range=''):
@@ -1085,8 +1081,6 @@ class WindCondition(object):
         * snow_on_ground
         * hourly_values
         * hourly_wind_dirs
-        * isWindCondition
-
     """
     def __init__(self, wind_speed, wind_direction=0,
                  rain=False, snow_on_ground=False):
@@ -1227,7 +1221,6 @@ class SkyCondition(object):
         * month
         * day_of_month
         * hourly_sky_cover
-        * isSkyCondition
         * sky_types
         * solar_model
     """
@@ -1489,7 +1482,6 @@ class RevisedClearSkyCondition(SkyCondition):
     Properties:
         * day_of_month
         * hourly_sky_cover
-        * isSkyCondition
         * month
         * sky_types
         * solar_model

--- a/ladybug/designday.py
+++ b/ladybug/designday.py
@@ -31,9 +31,29 @@ if (sys.version_info > (3, 0)):
 class DDY(object):
     """A DDY object containing all of the data of a .ddy file.
 
-    Properties:
+    Args:
         location: A Ladybug location object
         design_days: A list of the design days in the ddy file.
+
+    Properties:
+        * hourly_barometric_pressure
+        * hourly_datetimes
+        * hourly_dew_point
+        * hourly_dry_bulb
+        * hourly_horizontal_infrared
+        * hourly_relative_humidity
+        * hourly_sky_cover
+        * hourly_solar_radiation
+        * hourly_wind_direction
+        * hourly_wind_speed
+        * humidity_condition
+        * isDesignDay
+        * location
+        * name
+        * sky_condition
+
+wind_condition
+Get or set the wind conditions.
     """
     _location_format = re.compile(
         r"(Site:Location,(.|\n)*?((;\s*!)|(;\s*\n)|(;\n)))")
@@ -54,9 +74,14 @@ class DDY(object):
         """Create a DDY from a dictionary.
 
         Args:
-            data = {
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+            {
             "location": ladybug Location schema,
-            "design_days": [] // list of ladybug DesignDay schemas}
+            "design_days": [] // list of ladybug DesignDay schemas
+            }
         """
         required_keys = ('location', 'design_days')
         for key in required_keys:
@@ -69,7 +94,7 @@ class DDY(object):
     def from_ddy_file(cls, file_path):
         """Initalize from a ddy file object from an existing ddy file.
 
-        args:
+        Args:
             file_path: A string representing a complete path to the .ddy file.
         """
         # check that the file is there
@@ -119,7 +144,7 @@ class DDY(object):
     def from_design_day(cls, design_day):
         """Initalize from a ddy file object from a ladybug design day object.
 
-        args:
+        Args:
             design_day: A Ladybug DesignDay object.
         """
         return cls(design_day.location, [design_day])
@@ -127,7 +152,7 @@ class DDY(object):
     def save(self, file_path):
         """Save ddy object as a .ddy file.
 
-        args:
+        Args:
             file_path: A string representing the path to write the ddy file to.
         """
         # write all data into the file
@@ -213,7 +238,7 @@ class DDY(object):
 class DesignDay(object):
     """An object representing design day conditions.
 
-    properties:
+    Args:
         name: A text string to set the name of the design day
         day_type: Choose from 'SummerDesignDay', 'WinterDesignDay' or other
             EnergyPlus days visible under the day_types property of this object.
@@ -222,6 +247,15 @@ class DesignDay(object):
         humidity_condition: Ladyubug HumidityCondition object
         wind_condition: Ladyubug WindCondition object
         sky_condition: Ladybug SkyCondition object
+
+    Properties:
+        * name
+        * day_type
+        * location
+        * dry_bulb_condition
+        * humidity_condition
+        * wind_condition
+        * sky_condition
     """
     # possible day types
     day_types = ('SummerDesignDay', 'WinterDesignDay', 'Sunday', 'Monday',
@@ -276,16 +310,6 @@ class DesignDay(object):
                  dry_bulb_condition, humidity_condition,
                  wind_condition, sky_condition):
         """Initalize the class
-
-        Args:
-            name: A text string to set the name of the design day
-            day_type: Choose from 'SummerDesignDay', 'WinterDesignDay' or other
-                EnergyPlus days visible under the day_types property of this object.
-            location: Location object for the design day
-            dry_bulb_condition: Ladyubug DryBulbCondition object
-            humidity_condition: Ladyubug HumidityCondition object
-            wind_condition: Ladyubug WindCondition object
-            sky_condition: Ladybug SkyCondition object
         """
         self.name = str(name)
         self.day_type = day_type
@@ -300,14 +324,19 @@ class DesignDay(object):
         """Create a Design Day from a dictionary.
 
         Args:
-            data = {
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+            {
             "name": string,
             "day_type": string,
             "location": ladybug Location schema,
             "dry_bulb_condition": ladybug DryBulbCondition schema,
             "humidity_condition": ladybug HumidityCondition schema,
             "wind_condition": ladybug WindCondition schema,
-            "sky_condition": ladybug SkyCondition schema}
+            "sky_condition": ladybug SkyCondition schema
+            }
         """
         required_keys = ('name', 'day_type', 'location', 'dry_bulb_condition',
                          'humidity_condition', 'wind_condition', 'sky_condition')
@@ -324,7 +353,7 @@ class DesignDay(object):
     def from_ep_string(cls, ep_string, location):
         """Initalize from an EnergyPlus string of a SizingPeriod:DesignDay.
 
-        args:
+        Args:
             ep_string: A full string representing a SizingPeriod:DesignDay.
         """
         # format the object into a list of properties
@@ -498,7 +527,7 @@ class DesignDay(object):
         """Serialize object to an EnerygPlus SizingPeriod:DesignDay.
 
         Returns:
-            ep_string: A full string representing a SizingPeriod:DesignDay.
+            ep_string -- A full string representing a SizingPeriod:DesignDay.
         """
         # Put together the values in the order that they exist in the ddy file
         ep_vals = [self.name,
@@ -764,11 +793,18 @@ class DesignDay(object):
 class DryBulbCondition(object):
     """Represents dry bulb conditions on a design day.
 
-    Properties:
+    Args:
         dry_bulb_max
         dry_bulb_range
         modifier_type
         modifier_schedule
+
+    Properties:
+        * dry_bulb_max
+        * dry_bulb_range
+        * hourly_values
+        * isDryBulbCondition
+        * temp_multipliers
     """
     def __init__(self, dry_bulb_max, dry_bulb_range,
                  modifier_type='DefaultMultipliers', modifier_schedule=''):
@@ -783,11 +819,16 @@ class DryBulbCondition(object):
         """Create a Dry Bulb Condition from a dictionary.
 
         Args:
-            data = {
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+            {
             "dry_bulb_max": float,
             "dry_bulb_range": float,
             "modifier_type": string,
-            "modifier_schedule": string}
+            "modifier_schedule": string
+            }
         """
         # Check required and optional keys
         required_keys = ('dry_bulb_max', 'dry_bulb_range')
@@ -866,13 +907,23 @@ class DryBulbCondition(object):
 class HumidityCondition(object):
     """Represents humidity conditions on the design day.
 
-    Properties:
+    Args:
         hum_type: Choose from
             Wetbulb, Dewpoint, HumidityRatio, Enthalpy
         hum_value: The value of the condition above
         barometric_pressure: Default is to use pressure at sea level
         schedule: Optional humidity schedule
         wet_bulb_range: Optional wet bulb temperature range
+
+    Properties:
+        * hum_type
+        * hum_value
+        * barometric_pressure
+        * schedule
+        * wet_bulb_range
+        * hourly_pressure
+        * humid_types
+        * isHumidityCondition
     """
     def __init__(self, hum_type, hum_value, barometric_pressure=101325,
                  schedule='', wet_bulb_range=''):
@@ -888,12 +939,17 @@ class HumidityCondition(object):
         """Create a Humidity Condition from a dictionary.
 
         Args:
-            data = {
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+            {
             "hum_type": string,
             "hum_value": float,
             "barometric_pressure": float,
             "schedule": string,
-            "wet_bulb_range": string}
+            "wet_bulb_range": string
+            }
         """
         # Check required and optional keys
         required_keys = ('hum_type', 'hum_value')
@@ -911,7 +967,7 @@ class HumidityCondition(object):
     def hourly_dew_point_values(self, dry_bulb_condition):
         """Get a list of dew points (C) at each hour over the design day.
 
-        args:
+        Args:
             dry_bulb_condition: The dry bulb condition for the day.
         """
         hourly_dew_point = []
@@ -926,7 +982,7 @@ class HumidityCondition(object):
     def dew_point(self, db):
         """Get the dew point (C), which is constant throughout the day (except at saturation).
 
-        args:
+        Args:
             db: The maximum dry bulb temperature over the day.
         """
         if self._hum_type == 'Dewpoint':
@@ -1012,11 +1068,21 @@ class HumidityCondition(object):
 class WindCondition(object):
     """Represents wind and rain conditions on the design day.
 
-    Properties:
+    Args:
         wind_speed
         wind_direction
         rain
         snow_on_ground
+
+    Properties:
+        * wind_speed
+        * wind_direction
+        * rain
+        * snow_on_ground
+        * hourly_values
+        * hourly_wind_dirs
+        * isWindCondition
+
     """
     def __init__(self, wind_speed, wind_direction=0,
                  rain=False, snow_on_ground=False):
@@ -1031,11 +1097,16 @@ class WindCondition(object):
         """Create a Wind Condition from a dictionary.
 
         Args:
-            data = {
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+            {
             "wind_speed": float,
             "wind_direction": float,
             "rain": bool,
-            "snow_on_ground": bool}
+            "snow_on_ground": bool
+            }
         """
         # Check required and optional keys
         optional_keys = {'wind_direction': 0, 'rain': False, 'snow_on_ground': False}
@@ -1136,11 +1207,21 @@ class WindCondition(object):
 class SkyCondition(object):
     """An object representing a sky on the design day.
 
-    Properties:
+    Args:
         solar_model
         month
         day_of_month
         daylight_savings_indicator
+        beam_shced
+        diff_sched
+
+    Properties:
+        * month
+        * day_of_month
+        * hourly_sky_cover
+        * isSkyCondition
+        * sky_types
+        * solar_model
     """
     def __init__(self, solar_model, month, day_of_month,
                  daylight_savings_indicator='No',
@@ -1158,11 +1239,16 @@ class SkyCondition(object):
         """Create a Sky Condition from a dictionary.
 
         Args:
-            data = {
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+            {
             "solar_model": string,
             "month": int,
             "day_of_month": int,
-            "daylight_savings_indicator": string // "Yes" or "No"}
+            "daylight_savings_indicator": string // "Yes" or "No"
+            }
         """
         # Check required and optional keys
         required_keys = ('solar_model', 'month', 'day_of_month')
@@ -1273,11 +1359,17 @@ class SkyCondition(object):
 class OriginalClearSkyCondition(SkyCondition):
     """An object representing an original ASHRAE Clear Sky.
 
-    Properties:
+    Args:
         month
         day_of_month
         clearness
         daylight_savings_indicator
+
+    Properties:
+        * month
+        * day_of_month
+        * clearness
+        * daylight_savings_indicator
     """
     def __init__(self, month, day_of_month, clearness=1,
                  daylight_savings_indicator='No'):
@@ -1299,12 +1391,17 @@ class OriginalClearSkyCondition(SkyCondition):
         """Create a Sky Condition from a dictionary.
 
         Args:
-            data = {
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+            {
             "solar_model": string,
             "month": int,
             "day_of_month": int,
             "clearness": float,
-            "daylight_savings_indicator": string // "Yes" or "No"}
+            "daylight_savings_indicator": string // "Yes" or "No"
+            }
         """
         # Check required and optional keys
         required_keys = ('solar_model', 'month', 'day_of_month', 'clearness')
@@ -1369,12 +1466,22 @@ class OriginalClearSkyCondition(SkyCondition):
 class RevisedClearSkyCondition(SkyCondition):
     """An object representing an ASHRAE Revised Clear Sky (Tau model).
 
-    Properties:
+    Args:
         month
         day_of_month
         tau_b
         tau_d
         daylight_savings_indicator
+
+    Properties:
+        * day_of_month
+        * hourly_sky_cover
+        * isSkyCondition
+        * month
+        * sky_types
+        * solar_model
+        * tau_b
+        * tau_d
     """
     def __init__(self, month, day_of_month, tau_b, tau_d,
                  daylight_savings_indicator='No'):
@@ -1397,13 +1504,18 @@ class RevisedClearSkyCondition(SkyCondition):
         """Create a Sky Condition from a dictionary.
 
         Args:
-            data = {
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+            {
             "solar_model": string,
             "month": int,
             "day_of_month": int,
             "tau_b": float,
             "tau_d": float,
-            "daylight_savings_indicator": string // "Yes" or "No"}
+            "daylight_savings_indicator": string // "Yes" or "No"
+            }
         """
         # Check required and optional keys
         required_keys = ('solar_model', 'month', 'day_of_month', 'tau_b', 'tau_d')

--- a/ladybug/dt.py
+++ b/ladybug/dt.py
@@ -272,10 +272,9 @@ class Date(date):
     """Ladybug Date.
 
     Args:
-        month: A value for month between 1-12 (Defualt: 1).
-        day: A value for day between 1-31 (Defualt: 1).
-        leap_year: A boolean to indicate if date is for a leap year
-            (Default: False).
+        month: A value for month between 1-12. Defualt: 1.
+        day: A value for day between 1-31. Defualt: 1.
+        leap_year: A boolean to indicate if date is for a leap year. Default: False.
 
     Properties:
         * day

--- a/ladybug/dt.py
+++ b/ladybug/dt.py
@@ -24,15 +24,10 @@ class DateTime(datetime):
         * doy
         * hoy
         * int_hoy
-        * max
-        * microsecond
-        * min
         * minute
         * moy
         * int_hoy
         * float_hour
-        * resolution
-        * second
         * tzinfo
         * year
     """
@@ -280,8 +275,6 @@ class Date(date):
         * day
         * doy
         * leap_year
-        * max
-        * min
         * month
         * year
     """
@@ -414,12 +407,8 @@ class Time(time):
 
     Properties:
         * hour
-        * max
-        * microsecond
-        * min
         * minute
         * mod
-        * resolution
         * second
         * tzinfo
     """

--- a/ladybug/dt.py
+++ b/ladybug/dt.py
@@ -8,31 +8,39 @@ from datetime import datetime, date, time
 class DateTime(datetime):
     """Create Ladybug Date time.
 
+    Args:
+        month: A value for month between 1-12 (Defualt: 1).
+        day: A value for day between 1-31 (Defualt: 1).
+        hour: A value for hour between 0-23 (Defualt: 0).
+        minute: A value for month between 0-59 (Defualt: 0).
+        leap_year: A boolean to indicate if datetime is for a leap year
+            (Default: False).
+
     Properties:
-        month
-        day
-        hour
-        minute
-        leap_year
-        doy
-        hoy
-        moy
-        int_hoy
-        float_hour
+        * month
+        * day
+        * hour
+        * leap_year
+        * doy
+        * hoy
+        * int_hoy
+        * max
+        * microsecond
+        * min
+        * minute
+        * moy
+        * int_hoy
+        * float_hour
+        * resolution
+        * second
+        * tzinfo
+        * year
     """
 
     __slots__ = ()
 
     def __new__(cls, month=1, day=1, hour=0, minute=0, leap_year=False):
         """Create Ladybug datetime.
-
-        Args:
-            month: A value for month between 1-12 (Defualt: 1).
-            day: A value for day between 1-31 (Defualt: 1).
-            hour: A value for hour between 0-23 (Defualt: 0).
-            minute: A value for month between 0-59 (Defualt: 0).
-            leap_year: A boolean to indicate if datetime is for a leap year
-                (Default: False).
         """
         year = 2016 if leap_year else 2017
         hour, minute = Time._calculate_hour_and_minute(hour + minute / 60.0)
@@ -48,12 +56,16 @@ class DateTime(datetime):
         """Creat datetime from a dictionary.
 
         Args:
-            data: {
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+                {
                 'month': A value for month between 1-12. (Defualt: 1)
                 'day': A value for day between 1-31. (Defualt: 1)
                 'hour': A value for hour between 0-23. (Defualt: 0)
                 'minute': A value for month between 0-59. (Defualt: 0)
-            }
+                }
         """
         month = data['month'] if 'month' in data else 1
         day = data['day'] if 'day' in data else 1
@@ -120,6 +132,9 @@ class DateTime(datetime):
                 leap year. Default: False.
 
         Usage:
+
+        .. code-block:: shell
+
             dt = DateTime.from_date_time_string("31 Dec 12:00")
         """
         dt = datetime.strptime(datetime_string, '%d %b %H:%M')
@@ -256,23 +271,26 @@ class DateTime(datetime):
 class Date(date):
     """Ladybug Date.
 
+    Args:
+        month: A value for month between 1-12 (Defualt: 1).
+        day: A value for day between 1-31 (Defualt: 1).
+        leap_year: A boolean to indicate if date is for a leap year
+            (Default: False).
+
     Properties:
-        month
-        day
-        leap_year
-        doy
+        * day
+        * doy
+        * leap_year
+        * max
+        * min
+        * month
+        * year
     """
 
     __slots__ = ()
 
     def __new__(cls, month=1, day=1, leap_year=False):
         """Create Ladybug Date.
-
-        Args:
-            month: A value for month between 1-12 (Defualt: 1).
-            day: A value for day between 1-31 (Defualt: 1).
-            leap_year: A boolean to indicate if date is for a leap year
-                (Default: False).
         """
         year = 2016 if leap_year else 2017
         try:
@@ -285,10 +303,14 @@ class Date(date):
         """Create date from a dictionary.
 
         Args:
-            data: {
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+                {
                 'month': A value for month between 1-12. (Defualt: 1)
                 'day': A value for day between 1-31. (Defualt: 1)
-            }
+                }
         """
         month = data['month'] if 'month' in data else 1
         day = data['day'] if 'day' in data else 1
@@ -330,6 +352,8 @@ class Date(date):
         """Create Ladybug Date from a Date string.
 
         Usage:
+
+        .. code-block:: shell
 
             dt = Date.from_date_string("31 Dec")
         """
@@ -385,21 +409,26 @@ class Date(date):
 class Time(time):
     """Create Ladybug Time.
 
+    Args:
+        hour: A value for hour between 0-23 (Defualt: 0).
+        minute: A value for month between 0-59 (Defualt: 0).
+
     Properties:
-        hour
-        minute
-        mod
-        float_hour
+        * hour
+        * max
+        * microsecond
+        * min
+        * minute
+        * mod
+        * resolution
+        * second
+        * tzinfo
     """
 
     __slots__ = ()
 
     def __new__(cls, hour=0, minute=0):
         """Create Ladybug Time.
-
-        Args:
-            hour: A value for hour between 0-23 (Defualt: 0).
-            minute: A value for month between 0-59 (Defualt: 0).
         """
         hour, minute = cls._calculate_hour_and_minute(hour + minute / 60.0)
         try:
@@ -412,10 +441,14 @@ class Time(time):
         """Create time from a dictionary.
 
         Args:
-            data: {
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+                {
                 'hour': A value for hour between 0-23. (Defualt: 0)
                 'minute': A value for month between 0-59. (Defualt: 0)
-            }
+                }
         """
         hour = data['hour'] if 'hour' in data else 0
         minute = data['minute'] if 'minute' in data else 0
@@ -436,6 +469,8 @@ class Time(time):
         """Create Ladybug Time from a Time string.
 
         Usage:
+
+        .. code-block:: shell
 
             dt = Time.from_time_string("12:00")
         """

--- a/ladybug/dt.py
+++ b/ladybug/dt.py
@@ -58,13 +58,13 @@ class DateTime(datetime):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
                 {
-                'month': A value for month between 1-12. (Defualt: 1)
-                'day': A value for day between 1-31. (Defualt: 1)
-                'hour': A value for hour between 0-23. (Defualt: 0)
-                'minute': A value for month between 0-59. (Defualt: 0)
+                'month': 1  #A value for month between 1-12. (Defualt: 1)
+                'day': 1  # A value for day between 1-31. (Defualt: 1)
+                'hour': 0  # A value for hour between 0-23. (Defualt: 0)
+                'minute': 0  # A value for month between 0-59. (Defualt: 0)
                 }
         """
         month = data['month'] if 'month' in data else 1
@@ -133,7 +133,7 @@ class DateTime(datetime):
 
         Usage:
 
-        .. code-block:: shell
+        .. code-block:: python
 
             dt = DateTime.from_date_time_string("31 Dec 12:00")
         """
@@ -183,7 +183,7 @@ class DateTime(datetime):
 
     @property
     def float_hour(self):
-        """Get hour and minute as a float value (e.g. 6.25 for 6:15)."""
+        """Get hour and minute as a float value, e.g. 6.25 for 6:15."""
         return self.hour + self.minute / 60.0
 
     @property
@@ -305,11 +305,11 @@ class Date(date):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
                 {
-                'month': A value for month between 1-12. (Defualt: 1)
-                'day': A value for day between 1-31. (Defualt: 1)
+                'month': 1  # A value for month between 1-12. (Defualt: 1)
+                'day': 1  # A value for day between 1-31. (Defualt: 1)
                 }
         """
         month = data['month'] if 'month' in data else 1
@@ -353,7 +353,7 @@ class Date(date):
 
         Usage:
 
-        .. code-block:: shell
+        .. code-block:: python
 
             dt = Date.from_date_string("31 Dec")
         """
@@ -443,11 +443,11 @@ class Time(time):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
                 {
-                'hour': A value for hour between 0-23. (Defualt: 0)
-                'minute': A value for month between 0-59. (Defualt: 0)
+                'hour': 0  # A value for hour between 0-23. (Defualt: 0)
+                'minute': 0  # A value for month between 0-59. (Defualt: 0)
                 }
         """
         hour = data['hour'] if 'hour' in data else 0
@@ -470,7 +470,7 @@ class Time(time):
 
         Usage:
 
-        .. code-block:: shell
+        .. code-block:: python
 
             dt = Time.from_time_string("12:00")
         """
@@ -493,7 +493,7 @@ class Time(time):
 
     @property
     def float_hour(self):
-        """Get hour and minute as a float value (e.g. 6.25 for 6:15)."""
+        """Get hour and minute as a float value, e.g. 6.25 for 6:15."""
         return self.hour + self.minute / 60.0
 
     def to_array(self):

--- a/ladybug/epw.py
+++ b/ladybug/epw.py
@@ -1674,13 +1674,13 @@ pdfs_v8.4.0/AuxiliaryPrograms.pdf
         *   33 Liquid Precipitation Depth
         *   34 Liquid Precipitation Quantity
         """
-        return EPWField(cls.FIELDS[field_number])
+        return EPWField(cls._fields[field_number])
 
     def __repr__(self):
         """EPW fields representation."""
         fields = (
             '{}: {}'.format(key, value['name'])
-            for key, value in self.FIELDS.items()
+            for key, value in self._fields.items()
         )
 
         return '\n'.join(fields)

--- a/ladybug/epw.py
+++ b/ladybug/epw.py
@@ -129,7 +129,7 @@ class EPW(object):
 
         Usage:
 
-        .. code-block:: shell
+        .. code-block:: python
 
             from ladybug.epw import EPW
             from ladybug.location import Location
@@ -188,32 +188,34 @@ class EPW(object):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
                 {
-                "location": {} , // ladybug location schema
-                "data_collections": [], // list of hourly annual hourly data collection
-                    schemas for each of the 35 fields within the EPW file.
-                "metadata": {},  // dict of metadata assigned to all data collections
-                "heating_dict": {}, // dict containing heating design conditions
-                "cooling_dict": {}, // dict containing cooling design conditions
-                "extremes_dict": {}, // dict containing extreme design conditions
-                "extreme_hot_weeks": {}, // dict with values of week-long ladybug
-                    analysis period schemas signifying extreme hot weeks.
-                "extreme_cold_weeks": {}, // dict with values of week-long ladybug
-                    analysis period schemas signifying extreme cold weeks.
-                "typical_weeks": {}, // dict with values of week-long ladybug
-                    analysis period schemas signifying typical weeks.
-                "monthly_ground_temps": {}, // dict with keys as floats signifying
-                    depths in meters below ground and values of monthly collection schema
-                "is_ip": Boolean // denote whether the data is in IP units
-                "is_leap_year": Boolean, // denote whether data is for a leap year
-                "daylight_savings_start": 0, // signify when daylight savings starts
-                    or 0 for no daylight savings
-                "daylight_savings_end" 0, // signify when daylight savings ends
-                    or 0 for no daylight savings
-                "comments_1": String, // epw comments
-                "comments_2": String // epw comments
+                "location": {} ,  # ladybug location schema
+                "data_collections": [],  # list of hourly annual hourly data collection
+                    # schemas for each of the 35 fields within the EPW file.
+                "metadata": {},  # dict of metadata assigned to all data collections
+                "heating_dict": {},  # dict containing heating design conditions
+                "cooling_dict": {},  # dict containing cooling design conditions
+                "extremes_dict": {},  # dict containing extreme design conditions
+                "extreme_hot_weeks": {},  # dict with values of week-long ladybug
+                    # analysis period schemas signifying extreme hot weeks.
+                "extreme_cold_weeks": {},  # dict with values of week-long ladybug
+                    # analysis period schemas signifying extreme cold weeks.
+                "typical_weeks": {},  # dict with values of week-long ladybug
+                    # analysis period schemas signifying typical weeks.
+                "monthly_ground_temps": {},  # dict with keys as floats signifying
+                    # depths in meters below ground and values of monthly
+                    # collection schema
+                "is_ip": False  # Boolean // denote whether the data is in IP units
+                "is_leap_year": False  # Boolean, denote whether data is for
+                                       # a leap year
+                "daylight_savings_start": 0,  # signify when daylight savings starts
+                                              # or 0 for no daylight savings
+                "daylight_savings_end" 0,  # signify when daylight savings ends
+                                           # or 0 for no daylight savings
+                "comments_1": ""  # String, epw comments
+                "comments_2": ""  # String, epw comments
                 }
         """
         # Initialize the class with all data missing
@@ -1401,7 +1403,7 @@ pdfs_v8.4.0/AuxiliaryPrograms.pdf
     (Chapter 2.9.1)
     """
 
-    FIELDS = {
+    _fields = {
         0: {'name': generic.GenericType('Year', 'yr'),
             'type': int,
             'unit': 'yr'

--- a/ladybug/epw.py
+++ b/ladybug/epw.py
@@ -24,59 +24,59 @@ except ImportError:
 class EPW(object):
     """An EPW object containing all of the data of an .epw file.
 
-    properties:
-        location
-        annual_heating_design_day_996
-        annual_heating_design_day_990
-        annual_cooling_design_day_004
-        annual_cooling_design_day_010
-        heating_design_condition_dictionary
-        cooling_design_condition_dictionary
-        extreme_design_condition_dictionary
-        extreme_hot_weeks
-        extreme_cold_weeks
-        typical_weeks
-        monthly_ground_temperature
-        header
+    Args:
+        file_path: Local file address to an .epw file.
 
-        years
-        dry_bulb_temperature
-        dew_point_temperature
-        relative_humidity
-        atmospheric_station_pressure
-        extraterrestrial_horizontal_radiation
-        extraterrestrial_direct_normal_radiation
-        horizontal_infrared_radiation_intensity
-        global_horizontal_radiation
-        direct_normal_radiation
-        diffuse_horizontal_radiation
-        global_horizontal_illuminance
-        direct_normal_illuminance
-        diffuse_horizontal_illuminance
-        zenith_luminance
-        wind_direction
-        wind_speed
-        total_sky_cover
-        opaque_sky_cover
-        visibility
-        ceiling_height
-        present_weather_observation
-        present_weather_codes
-        precipitable_water
-        aerosol_optical_depth
-        snow_depth
-        days_since_last_snowfall
-        albedo
-        liquid_precipitation_depth
-        liquid_precipitation_quantity
-        sky_temperature
+    Properties:
+        * location
+        * annual_heating_design_day_996
+        * annual_heating_design_day_990
+        * annual_cooling_design_day_004
+        * annual_cooling_design_day_010
+        * heating_design_condition_dictionary
+        * cooling_design_condition_dictionary
+        * extreme_design_condition_dictionary
+        * extreme_hot_weeks
+        * extreme_cold_weeks
+        * typical_weeks
+        * monthly_ground_temperature
+        * header
+
+        * years
+        * dry_bulb_temperature
+        * dew_point_temperature
+        * relative_humidity
+        * atmospheric_station_pressure
+        * extraterrestrial_horizontal_radiation
+        * extraterrestrial_direct_normal_radiation
+        * horizontal_infrared_radiation_intensity
+        * global_horizontal_radiation
+        * direct_normal_radiation
+        * diffuse_horizontal_radiation
+        * global_horizontal_illuminance
+        * direct_normal_illuminance
+        * diffuse_horizontal_illuminance
+        * zenith_luminance
+        * wind_direction
+        * wind_speed
+        * total_sky_cover
+        * opaque_sky_cover
+        * visibility
+        * ceiling_height
+        * present_weather_observation
+        * present_weather_codes
+        * precipitable_water
+        * aerosol_optical_depth
+        * snow_depth
+        * days_since_last_snowfall
+        * albedo
+        * liquid_precipitation_depth
+        * liquid_precipitation_quantity
+        * sky_temperature
     """
 
     def __init__(self, file_path):
         """Initalize an EPW object from from a local .epw file.
-
-        Args:
-            file_path: Local file address to an .epw file.
         """
         self._file_path = os.path.normpath(file_path) if file_path is not None else None
         self._is_header_loaded = False
@@ -111,22 +111,26 @@ class EPW(object):
         all hourly data slots just possess the missing value for that data
         type. To obtain a EPW that is simulate-able in EnergyPlus, one must
         at least set the following properties:
-            location
-            dry_bulb_temperature
-            dew_point_temperature
-            relative_humidity
-            atmospheric_station_pressure
-            direct_normal_radiation
-            diffuse_horizontal_radiation
-            wind_direction
-            wind_speed
-            total_sky_cover
-            opaque_sky_cover or horizontal_infrared_radiation_intensity
+
+        * location
+        * dry_bulb_temperature
+        * dew_point_temperature
+        * relative_humidity
+        * atmospheric_station_pressure
+        * direct_normal_radiation
+        * diffuse_horizontal_radiation
+        * wind_direction
+        * wind_speed
+        * total_sky_cover
+        * opaque_sky_cover or horizontal_infrared_radiation_intensity
 
         Args:
             is_leap_year: A boolean to set whether the EPW object is for a leap year.
 
         Usage:
+
+        .. code-block:: shell
+
             from ladybug.epw import EPW
             from ladybug.location import Location
             epw = EPW.from_missing_values()
@@ -181,8 +185,12 @@ class EPW(object):
     def from_dict(cls, data):
         """ Create EPW from a dictionary.
 
-            Args:
-                data: {
+        Args:
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+                {
                 "location": {} , // ladybug location schema
                 "data_collections": [], // list of hourly annual hourly data collection
                     schemas for each of the 35 fields within the EPW file.
@@ -206,7 +214,7 @@ class EPW(object):
                     or 0 for no daylight savings
                 "comments_1": String, // epw comments
                 "comments_2": String // epw comments
-            }
+                }
         """
         # Initialize the class with all data missing
         epw_obj = cls(None)
@@ -723,7 +731,7 @@ class EPW(object):
     def save(self, file_path):
         """Save epw object as an epw file.
 
-        args:
+        Args:
             file_path: A string representing the path to write the epw file to.
         """
         # load data if it's  not loaded convert to SI if it is in IP
@@ -827,42 +835,44 @@ class EPW(object):
         EPWFields.fields
 
         Args:
-            field_number: a value between 0 to 34 for different available epw fields.
-            0 Year
-            1 Month
-            2 Day
-            3 Hour
-            4 Minute
-            -
-            6 Dry Bulb Temperature
-            7 Dew Point Temperature
-            8 Relative Humidity
-            9 Atmospheric Station Pressure
-            10 Extraterrestrial Horizontal Radiation
-            11 Extraterrestrial Direct Normal Radiation
-            12 Horizontal Infrared Radiation Intensity
-            13 Global Horizontal Radiation
-            14 Direct Normal Radiation
-            15 Diffuse Horizontal Radiation
-            16 Global Horizontal Illuminance
-            17 Direct Normal Illuminance
-            18 Diffuse Horizontal Illuminance
-            19 Zenith Luminance
-            20 Wind Direction
-            21 Wind Speed
-            22 Total Sky Cover
-            23 Opaque Sky Cover
-            24 Visibility
-            25 Ceiling Height
-            26 Present Weather Observation
-            27 Present Weather Codes
-            28 Precipitable Water
-            29 Aerosol Optical Depth
-            30 Snow Depth
-            31 Days Since Last Snowfall
-            32 Albedo
-            33 Liquid Precipitation Depth
-            34 Liquid Precipitation Quantity
+            field_number: A value between 0 to 34 for different available epw fields.
+
+                *   0 Year
+                *   1 Month
+                *   2 Day
+                *   3 Hour
+                *   4 Minute
+                *   5 -
+                *   6 Dry Bulb Temperature
+                *   7 Dew Point Temperature
+                *   8 Relative Humidity
+                *   9 Atmospheric Station Pressure
+                *   10 Extraterrestrial Horizontal Radiation
+                *   11 Extraterrestrial Direct Normal Radiation
+                *   12 Horizontal Infrared Radiation Intensity
+                *   13 Global Horizontal Radiation
+                *   14 Direct Normal Radiation
+                *   15 Diffuse Horizontal Radiation
+                *   16 Global Horizontal Illuminance
+                *   17 Direct Normal Illuminance
+                *   18 Diffuse Horizontal Illuminance
+                *   19 Zenith Luminance
+                *   20 Wind Direction
+                *   21 Wind Speed
+                *   22 Total Sky Cover
+                *   23 Opaque Sky Cover
+                *   24 Visibility
+                *   25 Ceiling Height
+                *   26 Present Weather Observation
+                *   27 Present Weather Codes
+                *   28 Precipitable Water
+                *   29 Aerosol Optical Depth
+                *   30 Snow Depth
+                *   31 Days Since Last Snowfall
+                *   32 Albedo
+                *   33 Liquid Precipitation Depth
+                *   34 Liquid Precipitation Quantity
+
         Returns:
             An annual Ladybug list
         """
@@ -881,8 +891,8 @@ class EPW(object):
         this is a full numeric field (i.e. 23.6) and not an integer representation
         with tenths. Valid values range from -70C to 70 C. Missing value for this
         field is 99.9.
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(6)
 
@@ -893,8 +903,8 @@ class EPW(object):
         This is the dew point temperature in C at the time indicated. Note that this is
         a full numeric field (i.e. 23.6) and not an integer representation with tenths.
         Valid values range from -70 C to 70 C. Missing value for this field is 99.9
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(7)
 
@@ -904,8 +914,8 @@ class EPW(object):
 
         This is the Relative Humidity in percent at the time indicated. Valid values
         range from 0% to 110%. Missing value for this field is 999.
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(8)
 
@@ -916,8 +926,8 @@ class EPW(object):
         This is the station pressure in Pa at the time indicated. Valid values range
         from 31,000 to 120,000. (These values were chosen from the standard barometric
         pressure for all elevations of the World). Missing value for this field is 999999
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(9)
 
@@ -928,8 +938,8 @@ class EPW(object):
         This is the Extraterrestrial Horizontal Radiation in Wh/m2. It is not currently
         used in EnergyPlus calculations. It should have a minimum value of 0; missing
         value for this field is 9999.
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(10)
 
@@ -942,8 +952,8 @@ class EPW(object):
         of the atmosphere during the number of minutes preceding the time indicated).
         It is not currently used in EnergyPlus calculations. It should have a minimum
         value of 0; missing value for this field is 9999.
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(11)
 
@@ -955,8 +965,8 @@ class EPW(object):
         it is calculated from the Opaque Sky Cover field as shown in the following
         explanation. It should have a minimum value of 0; missing value for this field
         is 9999.
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(12)
 
@@ -969,8 +979,8 @@ class EPW(object):
         number of minutes preceding the time indicated.) It is not currently used in
         EnergyPlus calculations. It should have a minimum value of 0; missing value
         for this field is 9999.
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(13)
 
@@ -983,8 +993,8 @@ class EPW(object):
         sun's rays, during the number of minutes preceding the time indicated.) If the
         field is missing ( >= 9999) or invalid ( < 0), it is set to 0. Counts of such
         missing values are totaled and presented at the end of the runperiod.
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(14)
 
@@ -997,8 +1007,8 @@ class EPW(object):
         during the number of minutes preceding the time indicated.) If the field is
         missing ( >= 9999) or invalid ( < 0), it is set to 0. Counts of such missing
         values are totaled and presented at the end of the runperiod
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-        /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(15)
 
@@ -1012,8 +1022,8 @@ class EPW(object):
         currently used in EnergyPlus calculations. It should have a minimum value of 0;
         missing value for this field is 999999 and will be considered missing if greater
         than or equal to 999900.
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(16)
 
@@ -1028,8 +1038,8 @@ class EPW(object):
         value of 0; missing value for this field is 999999 and will be considered missing
         if greater than or equal to 999900.
 
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(17)
 
@@ -1044,8 +1054,8 @@ class EPW(object):
         value of 0; missing value for this field is 999999 and will be considered missing
         if greater than or equal to 999900.
 
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(18)
 
@@ -1058,8 +1068,8 @@ class EPW(object):
         the time indicated.) It is not currently used in EnergyPlus calculations.
         It should have a minimum value of 0; missing value for this field is 9999.
 
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(19)
 
@@ -1072,8 +1082,8 @@ class EPW(object):
         indicated. If calm, direction equals zero.) Values can range from 0 to 360.
         Missing value is 999.
 
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(20)
 
@@ -1084,8 +1094,8 @@ class EPW(object):
         This is the wind speed in m/sec. (Wind speed at time indicated.) Values can
         range from 0 to 40. Missing value is 999.
 
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(21)
 
@@ -1098,8 +1108,8 @@ class EPW(object):
         or obscuring phenomena at the hour indicated at the time indicated.) Minimum
         value is 0; maximum value is 10; missing value is 99.
 
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(22)
 
@@ -1115,8 +1125,8 @@ class EPW(object):
         Horizontal Infrared Radiation Intensity. Minimum value is 0; maximum value is
         10; missing value is 99.
 
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(23)
 
@@ -1128,8 +1138,8 @@ class EPW(object):
         indicated.) It is not currently used in EnergyPlus calculations. Missing
         value is 9999.
 
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(24)
 
@@ -1141,8 +1151,8 @@ class EPW(object):
         88888 is cirroform ceiling.) It is not currently used in EnergyPlus calculations.
         Missing value is 99999
 
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(25)
 
@@ -1156,8 +1166,8 @@ class EPW(object):
         Present Weather Codes) is for rain/wet surfaces, a missing observation field or
         a missing weather code implies no rain.
 
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(26)
 
@@ -1175,8 +1185,8 @@ class EPW(object):
         representing liquid precipitation - where the surfaces of the building would be
         wet. EnergyPlus uses "Snow Depth" to determine if snow is on the ground.
 
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(27)
 
@@ -1190,8 +1200,8 @@ class EPW(object):
         (primarily due to the unreliability of the reporting of this value). Missing
         value is 999.
 
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(28)
 
@@ -1202,8 +1212,8 @@ class EPW(object):
         This is the value for Aerosol Optical Depth in thousandths. It is not currently
         used in EnergyPlus calculations. Missing value is .999.
 
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(29)
 
@@ -1215,8 +1225,8 @@ class EPW(object):
         is on the ground and, thus, the ground reflectance may change. Missing value
         is 999.
 
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(30)
 
@@ -1227,8 +1237,8 @@ class EPW(object):
         This is the value for Days Since Last Snowfall. It is not currently used in
         EnergyPlus calculations. Missing value is 99.
 
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(31)
 
@@ -1239,8 +1249,8 @@ class EPW(object):
         The ratio (unitless) of reflected solar irradiance to global horizontal
         irradiance. It is not currently used in EnergyPlus.
 
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(32)
 
@@ -1254,8 +1264,8 @@ class EPW(object):
         Conversely, if the precipitation flag shows rain and this field is missing or
         zero, it is set to 1.5 (mm).
 
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs
-            /pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs\
+/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(33)
 
@@ -1266,8 +1276,8 @@ class EPW(object):
         The period of accumulation (hr) for the liquid precipitation depth field.
         It is not currently used in EnergyPlus.
 
-        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/
-            pdfs/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
+        Read more at: https://energyplus.net/sites/all/modules/custom/nrel_custom/\
+pdfs/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         """
         return self._get_data_by_field(34)
 
@@ -1278,8 +1288,8 @@ class EPW(object):
         This value in degrees Celcius is derived from the Horizontal Infrared
         Radiation Intensity in Wh/m2. It represents the long wave radiant
         temperature of the sky
-        Read more at: https://bigladdersoftware.com/epx/docs/8-9/engineering-reference
-            /climate-calculations.html#energyplus-sky-temperature-calculation
+        Read more at: https://bigladdersoftware.com/epx/docs/8-9/engineering-reference\
+/climate-calculations.html#energyplus-sky-temperature-calculation
         """
         # create sky temperature header
         sky_temp_header = Header(data_type=temperature.SkyTemperature(), unit='C',
@@ -1305,7 +1315,7 @@ class EPW(object):
         WEA carries radiation values from epw. Gendaymtx uses these values to
         generate the sky. For an annual analysis it is identical to using epw2wea.
 
-        args:
+        Args:
             file_path: Full file path for output file.
             hoys: List of hours of the year. Default is 0-8759.
         """
@@ -1386,9 +1396,8 @@ class EPW(object):
 class EPWFields(object):
     """EPW weather file fields.
 
-    Read more at:
-    https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs/
-        pdfs_v8.4.0/AuxiliaryPrograms.pdf
+    Read more at https://energyplus.net/sites/all/modules/custom/nrel_custom/pdfs/\
+pdfs_v8.4.0/AuxiliaryPrograms.pdf
     (Chapter 2.9.1)
     """
 
@@ -1627,41 +1636,41 @@ class EPWFields(object):
     def field_by_number(cls, field_number):
         """Return an EPWField based on field number.
 
-        0 Year
-        1 Month
-        2 Day
-        3 Hour
-        4 Minute
-        -
-        6 Dry Bulb Temperature
-        7 Dew Point Temperature
-        8 Relative Humidity
-        9 Atmospheric Station Pressure
-        10 Extraterrestrial Horizontal Radiation
-        11 Extraterrestrial Direct Normal Radiation
-        12 Horizontal Infrared Radiation Intensity
-        13 Global Horizontal Radiation
-        14 Direct Normal Radiation
-        15 Diffuse Horizontal Radiation
-        16 Global Horizontal Illuminance
-        17 Direct Normal Illuminance
-        18 Diffuse Horizontal Illuminance
-        19 Zenith Luminance
-        20 Wind Direction
-        21 Wind Speed
-        22 Total Sky Cover
-        23 Opaque Sky Cover
-        24 Visibility
-        25 Ceiling Height
-        26 Present Weather Observation
-        27 Present Weather Codes
-        28 Precipitable Water
-        29 Aerosol Optical Depth
-        30 Snow Depth
-        31 Days Since Last Snowfall
-        32 Albedo
-        33 Liquid Precipitation Depth
-        34 Liquid Precipitation Quantity
+        *   0 Year
+        *   1 Month
+        *   2 Day
+        *   3 Hour
+        *   4 Minute
+        *   5 -
+        *   6 Dry Bulb Temperature
+        *   7 Dew Point Temperature
+        *   8 Relative Humidity
+        *   9 Atmospheric Station Pressure
+        *   10 Extraterrestrial Horizontal Radiation
+        *   11 Extraterrestrial Direct Normal Radiation
+        *   12 Horizontal Infrared Radiation Intensity
+        *   13 Global Horizontal Radiation
+        *   14 Direct Normal Radiation
+        *   15 Diffuse Horizontal Radiation
+        *   16 Global Horizontal Illuminance
+        *   17 Direct Normal Illuminance
+        *   18 Diffuse Horizontal Illuminance
+        *   19 Zenith Luminance
+        *   20 Wind Direction
+        *   21 Wind Speed
+        *   22 Total Sky Cover
+        *   23 Opaque Sky Cover
+        *   24 Visibility
+        *   25 Ceiling Height
+        *   26 Present Weather Observation
+        *   27 Present Weather Codes
+        *   28 Precipitable Water
+        *   29 Aerosol Optical Depth
+        *   30 Snow Depth
+        *   31 Days Since Last Snowfall
+        *   32 Albedo
+        *   33 Liquid Precipitation Depth
+        *   34 Liquid Precipitation Quantity
         """
         return EPWField(cls.FIELDS[field_number])
 

--- a/ladybug/futil.py
+++ b/ladybug/futil.py
@@ -41,7 +41,7 @@ def nukedir(target_dir, rmdir=False):
 
     Usage:
 
-    .. code-block:: shell
+    .. code-block:: python
 
         nukedir("c:/ladybug/libs", True)
     """

--- a/ladybug/futil.py
+++ b/ladybug/futil.py
@@ -40,6 +40,9 @@ def nukedir(target_dir, rmdir=False):
     """Delete all the files inside target_dir.
 
     Usage:
+
+    .. code-block:: shell
+
         nukedir("c:/ladybug/libs", True)
     """
     d = os.path.normpath(target_dir)

--- a/ladybug/graphic.py
+++ b/ladybug/graphic.py
@@ -12,35 +12,35 @@ from ladybug_geometry.geometry3d.plane import Plane
 class GraphicContainer(object):
     """Graphic container used to get legends, title locations, and colors for any graphic.
 
+    Args:
+        values: A List or Tuple of numerical values that will be used to
+            generate the legend and colors.
+        min_point: A Point3D object for the minimum of the bounding box
+            around the graphic geometry.
+        max_point: A Point3D object for the maximum of the  bounding box
+            around the graphic geometry.
+        legend_parameters: An Optional LegendParameter object to override
+            default parameters of the legend.
+        data_type: Optional DataType from the ladybug datatype module, which
+            will be used to assign default legend properties. (ie. Temperature())
+        unit: Optional text string for the units of the values. (ie. 'C')
+
     Properties:
-        values
-        min_point
-        max_point
-        legend_parameters
-        data_type
-        unit
-        legend
-        value_colors
-        lower_title_location
-        upper_title_location
+        * values
+        * min_point
+        * max_point
+        * legend_parameters
+        * data_type
+        * unit
+        * legend
+        * value_colors
+        * lower_title_location
+        * upper_title_location
     """
 
     def __init__(self, values, min_point, max_point,
                  legend_parameters=None, data_type=None, unit=None):
         """Initialize graphic container.
-
-        Args:
-            values: A List or Tuple of numerical values that will be used to
-                generate the legend and colors.
-            min_point: A Point3D object for the minimum of the bounding box
-                around the graphic geometry.
-            max_point: A Point3D object for the maximum of the  bounding box
-                around the graphic geometry.
-            legend_parameters: An Optional LegendParameter object to override
-                default parameters of the legend.
-            data_type: Optional DataType from the ladybug datatype module, which
-                will be used to assign default legend properties. (ie. Temperature())
-            unit: Optional text string for the units of the values. (ie. 'C')
         """
         # check the inputs
         assert isinstance(min_point, Point3D), \
@@ -111,13 +111,18 @@ class GraphicContainer(object):
         """Create a graphic container from a dictionary.
 
         Args:
-            data: {
-            "values": (0, 10),
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+            {
+            "values": [0, 10],
             "min_point": {"x": 0, "y": 0, "z": 0},
-            "max_point": {"x": 10, "y": 10, "z": 0}],
+            "max_point": {"x": 10, "y": 10, "z": 0},
             "legend_parameters": None,
             "data_type": None,
-            "unit": None}
+            "unit": None
+            }
         """
         optional_keys = ('legend_parameters', 'data_type', 'unit')
         for key in optional_keys:

--- a/ladybug/graphic.py
+++ b/ladybug/graphic.py
@@ -113,7 +113,7 @@ class GraphicContainer(object):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
             {
             "values": [0, 10],

--- a/ladybug/header.py
+++ b/ladybug/header.py
@@ -26,7 +26,6 @@ class Header(object):
         * unit
         * analysis_period
         * metadata
-        * isHeader
     """
 
     __slots__ = ('_data_type', '_unit', '_analysis_period', '_metadata')

--- a/ladybug/header.py
+++ b/ladybug/header.py
@@ -61,13 +61,13 @@ class Header(object):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
                 {
-                "data_type": {}, //Type of data (e.g. Temperature)
-                "unit": string,
-                "analysis_period": {} // A Ladybug AnalysisPeriod
-                "metadata": {}, // A dictionary of metadata
+                "data_type": {},  # Type of data (e.g. Temperature)
+                "unit": "",  # string
+                "analysis_period": {},  # A Ladybug AnalysisPeriod
+                "metadata": {}  # A dictionary of metadata
                 }
         """
         # assign default values

--- a/ladybug/header.py
+++ b/ladybug/header.py
@@ -14,12 +14,19 @@ class Header(object):
     Header carries meatdata for DataCollections including data type, unit
     and analysis period.
 
-    Attributes:
+    Args:
         data_type: A DataType object. (e.g. Temperature)
         unit: data_type unit (Default: None).
         analysis_period: A Ladybug analysis period (Defualt: None)
         metadata: Optional dictionary of additional metadata,
             containing information such as 'source', 'city', or 'zone'.
+
+    Properties:
+        * data_type
+        * unit
+        * analysis_period
+        * metadata
+        * isHeader
     """
 
     __slots__ = ('_data_type', '_unit', '_analysis_period', '_metadata')
@@ -27,13 +34,6 @@ class Header(object):
     def __init__(self, data_type, unit=None,
                  analysis_period=None, metadata=None):
         """Initiate Ladybug header for lists.
-
-        Args:
-            data_type: A DataType object. (e.g. Temperature)
-            unit: data_type unit (Default: None)
-            analysis_period: A Ladybug analysis period (Defualt: None)
-            metadata: Optional dictionary of additional metadata,
-                containing information such as 'source', 'city', or 'zone'.
         """
         assert isinstance(data_type, DataTypeBase), \
             'data_type must be a Ladybug DataType. Got {}'.format(type(data_type))
@@ -59,12 +59,16 @@ class Header(object):
         """Create a header from a dictionary.
 
         Args:
-            data: {
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+                {
                 "data_type": {}, //Type of data (e.g. Temperature)
                 "unit": string,
                 "analysis_period": {} // A Ladybug AnalysisPeriod
                 "metadata": {}, // A dictionary of metadata
-            }
+                }
         """
         # assign default values
         assert 'data_type' in data, 'Required keyword "data_type" is missing!'

--- a/ladybug/legend.py
+++ b/ladybug/legend.py
@@ -21,27 +21,36 @@ if (sys.version_info > (3, 0)):  # python 3
 class Legend(object):
     """Ladybug legend used to get legend geometry, legend text, generate colors, etc.
 
+    Args:
+        values: A List or Tuple of numerical values that will be used to
+            generate the legend and colors.
+        legend_parameters: An Optional LegendParameter object to override
+            default parameters of the legend.
+
     Properties:
-        legend_parameters
-        values
-        value_colors
-        title
-        title_location
-        title_location_2d
-        segment_text
-        segment_text_location
-        segment_text_location_2d
-        segment_mesh
-        segment_mesh_2d
-        color_range
-        segment_numbers
-        segment_colors
-        segment_length
-        is_min_default
-        is_max_default
+        * legend_parameters
+        * values
+        * value_colors
+        * title
+        * title_location
+        * title_location_2d
+        * segment_text
+        * segment_text_location
+        * segment_text_location_2d
+        * segment_mesh
+        * segment_mesh_2d
+        * color_range
+        * segment_numbers
+        * segment_colors
+        * segment_length
+        * is_min_default
+        * is_max_default
 
     Usage:
-        ##
+
+    .. code-block:: shell
+
+        1.
         data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         legend = Legend(data, LegendParameters(segment_count=6))
         print(legend.segment_text)
@@ -53,16 +62,19 @@ class Legend(object):
         >> ((R:75, G:107, B:169), (R:159, G:189, B:238), (R:224, G:229, B:145),
             (R:247, G:200, B:53), (R:234, G:113, B:0), (R:234, G:38, B:0))
 
-        ##
+        2.
         data = [100, 300, 500, 1000, 2000, 3000]
         legend_par = LegendParameters(min=300, max=2000, segment_count=3)
-        legend_par.ordinal_dictionary = {300: 'low', 1150: 'desired', 2000: 'too much'}
+        legend_par.ordinal_dictionary = {300: 'low', 1150: 'desired',
+            2000: 'too much'}
         legend = Legend(data, legend_par)
         print(legend.segment_text)
         print(legend.segment_mesh)
         print(legend.segment_colors)
-        print(legend.value_colors)  # colors in between dict categories are interpolated
-        legend.legend_parameters.continuous_colors = False  # get data in only 3 colors
+        print(legend.value_colors)  # colors in between dict categories
+            are interpolated
+        legend.legend_parameters.continuous_colors = False  # get data in
+            only 3 colors
         print(legend.value_colors)  # data colors align with segment_count
 
         >> ['low', 'desired', 'too much']
@@ -73,7 +85,7 @@ class Legend(object):
         >> ((R:75, G:107, B:169), (R:115, G:147, B:202), (R:115, G:147, B:202),
             (R:115, G:147, B:202), (R:115, G:147, B:202), (R:234, G:38, B:0))
 
-        ##
+        3.
         data = [-0.5, 0, 0.5]
         legend_par = LegendParameters(min=-1, max=1, segment_count=3)
         legend_par.ordinal_dictionary = {-3: 'Cold', -2: 'Cool', -1: 'Slightly Cool',
@@ -97,13 +109,7 @@ class Legend(object):
 
     def __init__(self, values, legend_parameters=None):
         """Initalize Ladybug Legend.
-
-        Args:
-            values: A List or Tuple of numerical values that will be used to
-                generate the legend and colors.
-            legend_parameters: An Optional LegendParameter object to override
-                default parameters of the legend.
-            """
+        """
         # check the inputs
         assert isinstance(values, Iterable) \
             and not isinstance(values, (str, dict, bytes, bytearray)), \
@@ -135,9 +141,14 @@ class Legend(object):
         """Create a legend from a dictionary.
 
         Args:
-            data: {
-            "values": (0, 10),
-            "legend_parameters": None}
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+            {
+            "values": [0, 10],
+            "legend_parameters": None
+            }
         """
         if 'legend_parameters' not in data:
             data['legend_parameters'] = None
@@ -387,33 +398,52 @@ class LegendParameters(object):
 
     All properties of LegendParameters are set-able (except the is_..._default ones).
 
-    Properties:
-        min
-        max
-        segment_count
-        colors
-        continuous_colors
-        continuous_legend
-        title
-        ordinal_dictionary
-        decimal_count
-        include_larger_smaller
-        vertical
-        base_plane
-        segment_height
-        segment_width
-        text_height
-        font
+    Args:
+        min: A number to set the lower boundary of the legend. If None, the
+            minimum of the values associated with the legend will be used.
+        max: A number to set the upper boundary of the legend. If None, the
+            maximum of the values associated with the legend will be used.
+        segment_count: An interger representing the number of steps between
+            the high and low boundary of the legend. The default is set to 11
+            and any custom values input in here should always be greater than or
+            equal to 2.
+        colors: An list of color objects. Default is Ladybug's original colorset.
+        title: Text string for Legend title. Typically, the units of the data are
+            used here but the type of data might also be used. Default is
+            an empty string.
+        base_plane: A Ladybug Plane object to note the starting point from
+            where the legend will be genrated. The default is the world XY plane
+            at origin (0, 0, 0).
 
-        is_segment_count_default
-        is_title_default
-        is_base_plane_default
-        is_segment_height_default
-        is_segment_width_default
-        is_text_height_default
+    Properties:
+        * min
+        * max
+        * segment_count
+        * colors
+        * continuous_colors
+        * continuous_legend
+        * title
+        * ordinal_dictionary
+        * decimal_count
+        * include_larger_smaller
+        * vertical
+        * base_plane
+        * segment_height
+        * segment_width
+        * text_height
+        * font
+
+        * is_segment_count_default
+        * is_title_default
+        * is_base_plane_default
+        * is_segment_height_default
+        * is_segment_width_default
+        * is_text_height_default
 
     Usage:
-        ##
+
+    .. code-block:: json
+
         lp = LegendParameters(min=0, max=100, segment_count=6)
         lp.vertical = False
         lp.segment_width = 5
@@ -422,23 +452,6 @@ class LegendParameters(object):
     def __init__(self, min=None, max=None, segment_count=None,
                  colors=None, title=None, base_plane=None):
         """Initalize Ladybug Legend Parameters.
-
-        Args:
-            min: A number to set the lower boundary of the legend. If None, the
-                minimum of the values associated with the legend will be used.
-            max: A number to set the upper boundary of the legend. If None, the
-                maximum of the values associated with the legend will be used.
-            segment_count: An interger representing the number of steps between
-                the high and low boundary of the legend. The default is set to 11
-                and any custom values input in here should always be greater than or
-                equal to 2.
-            colors: An list of color objects. Default is Ladybug's original colorset.
-            title: Text string for Legend title. Typically, the units of the data are
-                used here but the type of data might also be used. Default is
-                an empty string.
-            base_plane: A Ladybug Plane object to note the starting point from
-                where the legend will be genrated. The default is the world XY plane
-                at origin (0, 0, 0).
         """
         self._min = None
         self._max = None
@@ -464,11 +477,16 @@ class LegendParameters(object):
     def from_dict(cls, data):
         """Create a color range from a dictionary.
 
-        Args:
-            data: {
+    Args:
+        data: A python dictionary in the following format
+
+    .. code-block:: json
+
+            {
             "min": -3,
             "max": 3,
-            "segment_count": 7}
+            "segment_count": 7
+            }
         """
         optional_keys = ('min', 'max', 'segment_count',
                          'colors', 'continuous_colors', 'continuous_legend',

--- a/ladybug/legend.py
+++ b/ladybug/legend.py
@@ -48,7 +48,7 @@ class Legend(object):
 
     Usage:
 
-    .. code-block:: shell
+    .. code-block:: python
 
         1.
         data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
@@ -143,7 +143,7 @@ class Legend(object):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
             {
             "values": [0, 10],
@@ -396,7 +396,8 @@ class Legend(object):
 class LegendParameters(object):
     """Ladybug legend parameters used to customize legends.
 
-    All properties of LegendParameters are set-able (except the is_..._default ones).
+    All properties of LegendParameters are set-able (except the
+    is_someproperty_default ones).
 
     Args:
         min: A number to set the lower boundary of the legend. If None, the
@@ -442,7 +443,7 @@ class LegendParameters(object):
 
     Usage:
 
-    .. code-block:: json
+    .. code-block:: python
 
         lp = LegendParameters(min=0, max=100, segment_count=6)
         lp.vertical = False
@@ -480,7 +481,7 @@ class LegendParameters(object):
     Args:
         data: A python dictionary in the following format
 
-    .. code-block:: json
+    .. code-block:: python
 
             {
             "min": -3,

--- a/ladybug/location.py
+++ b/ladybug/location.py
@@ -8,7 +8,7 @@ import re
 class Location(object):
     """Ladybug Location.
 
-    Attributes:
+    Args:
         city: Name of the city as a string.
         state: Optional state in which the city is located.
         country: Name of the country as a string.
@@ -18,6 +18,20 @@ class Location(object):
         elevation: A number for elevation of the location.
         station_id: ID of the location if the location is represnting a weather station.
         source: Source of data (e.g. TMY, TMY3).
+
+    Properties:
+        * city
+        * country
+        * elevation
+        * ep_style_location_string
+        * isLocation
+        * latitude
+        * longitude
+        * meridian
+        * source
+        * state
+        * station_id
+        * time_zone
     """
 
     __slots__ = ("city", "state", "country", "_lat", "_lon", "_tz", "_elev",
@@ -41,12 +55,17 @@ class Location(object):
         """Create a location from a dictionary.
 
         Args:
-            data: {
-            "city": "-",
-            "latitude": 0,
-            "longitude": 0,
-            "time_zone": 0,
-            "elevation": 0}
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+                {
+                "city": "-",
+                "latitude": 0,
+                "longitude": 0,
+                "time_zone": 0,
+                "elevation": 0
+                }
         """
         optional_keys = ('city', 'state', 'country', 'latitude', 'longitude',
                          'time_zone', 'elevation', 'station_id', 'source')
@@ -66,6 +85,8 @@ class Location(object):
             locationString: Location string
 
         Usage:
+
+        .. code-block:: json
 
             l = Location.from_location(locationString)
         """

--- a/ladybug/location.py
+++ b/ladybug/location.py
@@ -57,7 +57,7 @@ class Location(object):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
                 {
                 "city": "-",
@@ -86,7 +86,7 @@ class Location(object):
 
         Usage:
 
-        .. code-block:: json
+        .. code-block:: python
 
             l = Location.from_location(locationString)
         """

--- a/ladybug/location.py
+++ b/ladybug/location.py
@@ -24,7 +24,6 @@ class Location(object):
         * country
         * elevation
         * ep_style_location_string
-        * isLocation
         * latitude
         * longitude
         * meridian

--- a/ladybug/rootfind.py
+++ b/ladybug/rootfind.py
@@ -18,7 +18,7 @@ def secant(a, b, fn, epsilon):
             trying to find and the target condition you are trying to satisfy.
             It should typically be structured in the following way:
 
-            .. code-block:: json
+            .. code-block:: python
 
                 def fn(value_trying_to_find):
                     funct(value_trying_to_find) - target_desired_from_funct
@@ -70,7 +70,7 @@ def bisect(a, b, fn, epsilon, target):
             trying to find and the target condition you are trying to satisfy.
             It should typically be structured in the following way:
 
-            .. code-block:: json
+            .. code-block:: python
 
                 def fn(value_trying_to_find):
                     funct(value_trying_to_find) - target_desired_from_funct

--- a/ladybug/rootfind.py
+++ b/ladybug/rootfind.py
@@ -4,28 +4,31 @@ from __future__ import division
 
 
 def secant(a, b, fn, epsilon):
-    """
-     One of the fasest root-finding algorithms.
-     The method calculates the slope of the function fn and this enables it to converge
-     to a solution very fast. However, if started too far away from a root, the method
-     may not converge (returning a None). For this reason, it is recommended that this
-     function be used first in any guess-and-check workflow and, if it fails to find a
-     root, the bisect() method should be used.
+    """One of the fasest root-finding algorithms.
+    The method calculates the slope of the function fn and this enables it to converge
+    to a solution very fast. However, if started too far away from a root, the method
+    may not converge (returning a None). For this reason, it is recommended that this
+    function be used first in any guess-and-check workflow and, if it fails to find a
+    root, the bisect() method should be used.
 
-     Args:
+    Args:
         a: The lowest possible boundary of the value you are tying to find.
         b: The highest possible boundary of the value you are tying to find.
         fn: A function representing the relationship between the value you are
             trying to find and the target condition you are trying to satisfy.
             It should typically be structured in the following way:
-            `def fn(value_trying_to_find):
-                funct(value_trying_to_find) - target_desired_from_funct`
+
+            .. code-block:: json
+
+                def fn(value_trying_to_find):
+                    funct(value_trying_to_find) - target_desired_from_funct
+
             ...but the subtraction should be swtiched if value_trying_to_find
             has a negative relationship with the funct.
         epsilon: The acceptable error in the target_desired_from_funct.
 
     Returns:
-        root: The value that gives the target_desired_from_funct.
+        root -- The value that gives the target_desired_from_funct.
 
     References
     ----------
@@ -54,8 +57,7 @@ def secant(a, b, fn, epsilon):
 
 
 def bisect(a, b, fn, epsilon, target):
-    """
-    The simplest root-finding algorithm.
+    """The simplest root-finding algorithm.
 
     It is extremely reliable. However, it converges slowly for this reason,
     it is recommended that this only be used after the secant() method has
@@ -67,15 +69,19 @@ def bisect(a, b, fn, epsilon, target):
         fn: A function representing the relationship between the value you are
             trying to find and the target condition you are trying to satisfy.
             It should typically be structured in the following way:
-            `def fn(value_trying_to_find):
-                funct(value_trying_to_find) - target_desired_from_funct`
+
+            .. code-block:: json
+
+                def fn(value_trying_to_find):
+                    funct(value_trying_to_find) - target_desired_from_funct
+
             ...but the subtraction should be swtiched if value_trying_to_find
             has a negative relationship with the funct.
         epsilon: The acceptable error in the target_desired_from_funct.
         target: The target slope (typically 0 for a local minima or maxima).
 
     Returns:
-        root: The value that gives the target_desired_from_funct.
+        root -- The value that gives the target_desired_from_funct.
 
     References
     ----------

--- a/ladybug/skymodel.py
+++ b/ladybug/skymodel.py
@@ -617,9 +617,9 @@ def disc(ghi, altitude, doy, pressure=101325,
 
     This implementation limits the clearness index to 1 by default.
 
-    The original report describing the DISC model [1]_ uses the
+    The original report describing the DISC model [1] uses the
     relative air mass rather than the absolute (pressure-corrected)
-    air mass. However, the NREL implementation of the DISC model [2]_
+    air mass. However, the NREL implementation of the DISC model [2]
     uses absolute air mass. PVLib Matlab also uses the absolute air mass.
     pvlib python defaults to absolute air mass, but the relative airmass
     can be used by supplying `pressure=None`.

--- a/ladybug/skymodel.py
+++ b/ladybug/skymodel.py
@@ -29,9 +29,12 @@ def ashrae_clear_sky(altitudes, month, sky_clearness=1):
             than 1.2. Default is set to 1.0.
 
     Returns:
-        dir_norm_rad: A list of direct normal radiation values for each
+        A tuple with two elements
+
+        -   dir_norm_rad: A list of direct normal radiation values for each
             of the connected altitudes in W/m2.
-        dif_horiz_rad: A list of diffuse horizontall radiation values for each
+
+        -   dif_horiz_rad: A list of diffuse horizontall radiation values for each
             of the connected altitudes in W/m2.
     """
     # apparent solar irradiation at air mass m = 0
@@ -71,6 +74,7 @@ def ashrae_revised_clear_sky(altitudes, tb, td, use_2017_model=False):
 
     By default, this function returns clear sky values following the
     methods originally published in the ASHRAE 2009 HOF.
+
     Args:
         altitudes: A list of solar altitudes in degrees.
         tb: A value indicating the beam optical depth of the sky.
@@ -83,9 +87,12 @@ def ashrae_revised_clear_sky(altitudes, tb, td, use_2017_model=False):
             for tb and td and so this input defaults to False.
 
     Returns:
-        dir_norm_rad: A list of direct normal radiation values for each
+        A tuple with two elements
+
+        -   dir_norm_rad: A list of direct normal radiation values for each
             of the connected altitudes in W/m2.
-        dif_horiz_rad: A list of diffuse horizontall radiation values for each
+
+        -   dif_horiz_rad: A list of diffuse horizontall radiation values for each
             of the connected altitudes in W/m2.
     """
     dir_norm_rad = []
@@ -139,7 +146,7 @@ def zhang_huang_solar(alt, cloud_cover, relative_humidity,
             Default is to use the average value over the earth's orbit (1355).
 
     Returns:
-        glob_ir: A global horizontall radiation value in W/m2.
+        glob_ir -- A global horizontall radiation value in W/m2.
     """
     # zhang-huang solar model regression constants
     C0, C1, C2, C3, C4, C5, D_COEFF, K_COEFF = 0.5598, 0.4982, \
@@ -193,9 +200,12 @@ def zhang_huang_solar_split(altitudes, doys, cloud_cover, relative_humidity,
             newer and more accurate DIRINT model. Default is False.
 
     Returns:
-        dir_norm_rad: A list of direct normal radiation values for each
+        A tuple with two elements
+
+        -   dir_norm_rad: A list of direct normal radiation values for each
             of the connected altitudes in W/m2.
-        dif_horiz_rad: A list of diffuse horizontall radiation values for each
+
+        -   dif_horiz_rad: A list of diffuse horizontall radiation values for each
             of the connected altitudes in W/m2.
     """
     # Calculate global horizontal irradiance using the original zhang-huang model
@@ -257,10 +267,15 @@ def estimate_illuminance_from_irradiance(
             the kastenyoung1989 model to compute this value.
 
     Returns:
-        gh_ill: Value for Global Horizontal Illuminance in lux.
-        dn_ill: Value for Direct Normal Illuminance in lux.
-        dh_ill: Value for Diffuse Horizontal Illuminance in lux.
-        z_lum: Value for Zenith Luminance in lux.
+        A tuple with four elements
+
+        -   gh_ill: Value for Global Horizontal Illuminance in lux.
+
+        -   dn_ill: Value for Direct Normal Illuminance in lux.
+
+        -   dh_ill: Value for Diffuse Horizontal Illuminance in lux.
+
+        -   z_lum: Value for Zenith Luminance in lux.
 
     """
     if altitude <= 0:  # sun is below the horizon, return 0 for all results
@@ -378,7 +393,7 @@ def calc_horizontal_infrared(sky_cover, dry_bulb, dew_point):
             in degrees C.
 
     Returns:
-        horiz_ir: A horizontal infrared radiation intensity value in W/m2.
+        horiz_ir -- A horizontal infrared radiation intensity value in W/m2.
     """
     # stefan-boltzmann constant
     SIGMA = 5.6697e-8
@@ -410,7 +425,7 @@ def calc_sky_temperature(horiz_ir, source_emissivity=1):
              most outdoor surfaces.
 
     Returns:
-        sky_temp: A sky temperature value in C.
+        sky_temp -- A sky temperature value in C.
     """
     sigma = 5.6697e-8  # stefan-boltzmann constant
     return ((horiz_ir / (source_emissivity * sigma)) ** 0.25) - 273.15
@@ -485,9 +500,9 @@ def dirint(ghi, altitudes, doys, pressures, use_delta_kt_prime=True,
             set to 0 for times with altitude values smaller than `min_altitude`.
 
     Returns:
-        dni: array-like
-            The modeled direct normal irradiance in W/m^2 provided by the
-            DIRINT model.
+        dni -- array-like.
+        The modeled direct normal irradiance in W/m^2 provided by the
+        DIRINT model.
     """
     # calculate kt_prime values
     kt_primes = []
@@ -640,12 +655,16 @@ def disc(ghi, altitude, doy, pressure=101325,
             to air mass in the original paper.
 
     Returns:
-        dni: The modeled direct normal irradiance
+        A tuple with two elements
+
+        -   dni: The modeled direct normal irradiance
             in W/m^2 provided by the
             Direct Insolation Simulation Code (DISC) model.
-        kt: Ratio of global to extraterrestrial
+
+        -   kt: Ratio of global to extraterrestrial
             irradiance on a horizontal plane.
-        am: Airmass
+
+        -   am: Airmass
     """
     if altitude > min_altitude and ghi > 0:
         # this is the I0 calculation from the reference
@@ -680,8 +699,11 @@ def _disc_kn(clearness_index, airmass, max_airmass=12):
             in calculating Kn.
 
     Returns:
-        Kn : numeric
-        am : numeric
+        A tuple with two elements
+
+        -   Kn : numeric
+
+        -   am : numeric
             airmass used in the calculation of Kn. am <= max_airmass.
     """
     # short names for equations
@@ -728,11 +750,11 @@ def get_extra_radiation(doy, solar_constant=1366.1):
             The solar constant.
 
     Returns:
-        dni_extra : float, array, or Series
-            The extraterrestrial radiation present in watts per square meter
-            on a surface which is normal to the sun. Pandas Timestamp and
-            DatetimeIndex inputs will yield a Pandas TimeSeries. All other
-            inputs will yield a float or an array of floats.
+        dni_extra -- float, array, or Series.
+        The extraterrestrial radiation present in watts per square meter
+        on a surface which is normal to the sun. Pandas Timestamp and
+        DatetimeIndex inputs will yield a Pandas TimeSeries. All other
+        inputs will yield a float or an array of floats.
     """
     # Calculates the day angle for the Earth's orbit around the Sun.
     B = (2. * math.pi / 365.) * (doy - 1)
@@ -776,8 +798,8 @@ def clearness_index(ghi, altitude, extra_radiation, min_sin_altitude=0.065,
             NREL's SRRL Fortran code used 0.82 for hourly data.
 
     Returns:
-        kt : numeric
-            Clearness index
+        kt -- numeric.
+        Clearness index
     """
     sin_altitude = math.sin(math.radians(altitude))
     I0h = extra_radiation * max(sin_altitude, min_sin_altitude)
@@ -798,7 +820,7 @@ def clearness_index_zenith_independent(clearness_index, airmass,
         ASHRAE Transactions-Research Series, pp. 354-369
 
     Args:
-        clearness_index: numeric
+        clearness_index: numeric.
             Ratio of global to extraterrestrial irradiance on a horizontal
             plane
         airmass: numeric
@@ -809,8 +831,8 @@ def clearness_index_zenith_independent(clearness_index, airmass,
             NREL's SRRL Fortran code used 0.82 for hourly data.
 
     Returns:
-        kt_prime : numeric
-            Zenith independent clearness index
+        kt_prime -- numeric.
+        Zenith independent clearness index
     """
     if airmass is not None:
         # Perez eqn 1
@@ -841,14 +863,14 @@ def get_absolute_airmass(airmass_relative, pressure=101325.):
         data," Solar Energy, vol. 51, pp. 121-138, 1993.
 
     Args:
-        airmass_relative: numeric
+        airmass_relative: numeric.
             The air mass at sea-level.
         pressure: numeric, default 101325
             The site pressure in Pascal.
 
     Returns:
-        airmass_absolute: numeric
-            Absolute (pressure corrected) air mass
+        airmass_absolute -- numeric.
+        Absolute (pressure corrected) air mass
     """
     if airmass_relative is not None:
         return airmass_relative * pressure / 101325.
@@ -892,25 +914,27 @@ def get_relative_airmass(altitude, model='kastenyoung1989'):
             model descriptions to determine which type of altitude angle is
             required. Apparent altitude angles must be calculated at sea level.
         model: string, default 'kastenyoung1989'
-            Available models include the following:
-            * 'simple' - secant(apparent altitude angle) -
-              Note that this gives -inf at altitude=0
-            * 'kasten1966' - See reference [1] -
-              requires apparent sun altitude
-            * 'youngirvine1967' - See reference [2] -
-              requires true sun altitude
-            * 'kastenyoung1989' - See reference [3] -
-              requires apparent sun altitude
-            * 'gueymard1993' - See reference [4] -
-              requires apparent sun altitude
-            * 'young1994' - See reference [5] -
-              requries true sun altitude
-            * 'pickering2002' - See reference [6] -
-              requires apparent sun altitude
+
+                Available models include the following:
+
+                *   'simple' - secant(apparent altitude angle) -
+                    Note that this gives -inf at altitude=0
+                *   'kasten1966' - See reference [1] -
+                    requires apparent sun altitude
+                *   'youngirvine1967' - See reference [2] -
+                    requires true sun altitude
+                *   'kastenyoung1989' - See reference [3] -
+                    requires apparent sun altitude
+                *   'gueymard1993' - See reference [4] -
+                    requires apparent sun altitude
+                *   'young1994' - See reference [5] -
+                    requries true sun altitude
+                *   'pickering2002' - See reference [6] -
+                    requires apparent sun altitude
 
     Returns:
-        airmass_relative: Relative airmass at sea level. Will return None for any
-            altitude angle smaller than 0 degrees.
+        airmass_relative -- Relative airmass at sea level. Will return None for any
+        altitude angle smaller than 0 degrees.
     """
     if altitude < 0:
         return None

--- a/ladybug/stat.py
+++ b/ladybug/stat.py
@@ -23,36 +23,42 @@ except ImportError:
 class STAT(object):
     """Import data from a local .stat file.
 
+    Args:
+        file_path: Address to a local .stat file.
+
     Properties:
-        location
-        ashrae_climate_zone
-        koppen_climate_zone
-        extreme_cold_week
-        extreme_hot_week
-        typical_winter_week
-        typical_spring_week
-        typical_summer_week
-        typical_autumn_week
-        other_typical_weeks
-        annual_heating_design_day_996
-        annual_heating_design_day_990
-        annual_cooling_design_day_004
-        annual_cooling_design_day_010
-        monthly_cooling_design_days_100
-        monthly_cooling_design_days_050
-        monthly_cooling_design_days_020
-        monthly_cooling_design_days_004
-        monthly_db_temp_050
-        monthly_wb_temp_050
-        monthly_db_temp_range_050
-        monthly_wb_temp_range_050
-        standard_pressure_at_elev
-        monthly_wind_conditions
-        monthly_ws_avg
-        monthly_wind_dirs
-        monthly_clear_sky_conditions
-        monthly_tau_beam
-        monthly_tau_diffuse
+        * location
+        * ashrae_climate_zone
+        * koppen_climate_zone
+        * extreme_cold_week
+        * extreme_hot_week
+        * typical_winter_week
+        * typical_spring_week
+        * typical_summer_week
+        * typical_autumn_week
+        * other_typical_weeks
+        * annual_heating_design_day_996
+        * annual_heating_design_day_990
+        * annual_cooling_design_day_004
+        * annual_cooling_design_day_010
+        * monthly_cooling_design_days_100
+        * monthly_cooling_design_days_050
+        * monthly_cooling_design_days_020
+        * monthly_cooling_design_days_004
+        * monthly_db_temp_050
+        * monthly_wb_temp_050
+        * monthly_db_temp_range_050
+        * monthly_wb_temp_range_050
+        * monthly_found
+        * standard_pressure_at_elev
+        * monthly_wind_conditions
+        * monthly_ws_avg
+        * monthly_wind_dirs
+        * monthly_clear_sky_conditions
+        * monthly_tau_beam
+        * monthly_tau_diffuse
+        * isStat
+        * file_path
     """
     # categories used for parsing text
     _months = ('Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul',
@@ -95,9 +101,6 @@ class STAT(object):
 
     def __init__(self, file_path):
         """Initalize the class.
-
-        Args:
-            file_path: Address to a local .stat file.
         """
         if file_path is not None:
             if not os.path.isfile(file_path):
@@ -120,8 +123,12 @@ class STAT(object):
     def from_dict(cls, data):
         """ Create Stat from a dictionary.
 
-            Args:
-                data: {
+        Args:
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+                {
                 'location': {} , // ladybug location schema
                 'ashrae_climate_zone': str,
                 'koppen_climate_zone': str,
@@ -146,7 +153,7 @@ class STAT(object):
                 "standard_pressure_at_elev": float, // float value for pressure in Pa
                 "monthly_tau_beam":[], // list of 12 float values for each month
                 "monthly_tau_diffuse": [] // list of 12 float values for each month
-            }
+                }
         """
         # Initialize the class with all data missing
         stat_ob = cls(None)

--- a/ladybug/stat.py
+++ b/ladybug/stat.py
@@ -57,7 +57,6 @@ class STAT(object):
         * monthly_clear_sky_conditions
         * monthly_tau_beam
         * monthly_tau_diffuse
-        * isStat
         * file_path
     """
     # categories used for parsing text

--- a/ladybug/stat.py
+++ b/ladybug/stat.py
@@ -126,33 +126,33 @@ class STAT(object):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
                 {
-                'location': {} , // ladybug location schema
-                'ashrae_climate_zone': str,
-                'koppen_climate_zone': str,
-                'extreme_cold_week': {}, // ladybug analysis period schema
-                'extreme_hot_week': {}, // ladybug analysis period schema
-                'typical_weeks': {}, // dict of ladybug analysis period schemas
-                'heating_dict': {}, // dict containing heating design conditions
-                'cooling_dict': {}, // dict containing cooling design conditions
-                "monthly_db_50": [],  // list of 12 float values for each month
-                "monthly_wb_50": [],  // list of 12 float values for each month
-                "monthly_db_range_50": [],  // list of 12 float values for each month
-                "monthly_wb_range_50": [],  // list of 12 float values for each month
-                "monthly_db_100": [],  // list of 12 float values for each month
-                "monthly_wb_100": [],  // list of 12 float values for each month
-                "monthly_db_20": [],  // list of 12 float values for each month
-                "monthly_wb_20": [],  // list of 12 float values for each month
-                "monthly_db_04": [],  // list of 12 float values for each month
-                "monthly_wb_04": [],  // list of 12 float values for each month
-                "monthly_wind": [],  // list of 12 float values for each month
-                "monthly_wind_dirs": [], // matrix with 12 cols for months of the year
-                    and 8 rows for the cardinal directions.
-                "standard_pressure_at_elev": float, // float value for pressure in Pa
-                "monthly_tau_beam":[], // list of 12 float values for each month
-                "monthly_tau_diffuse": [] // list of 12 float values for each month
+                "location": {},  # ladybug location schema
+                "ashrae_climate_zone": "",  # str
+                "koppen_climate_zone": "", # str
+                "extreme_cold_week": {},  # ladybug analysis period schema
+                "extreme_hot_week": {},  # ladybug analysis period schema
+                "typical_weeks": {},  # dict of ladybug analysis period schemas
+                "heating_dict": {},  # dict containing heating design conditions
+                "cooling_dict": {},  # dict containing cooling design conditions
+                "monthly_db_50": [],  # list of 12 float values for each month
+                "monthly_wb_50": [],  # list of 12 float values for each month
+                "monthly_db_range_50": [],  # list of 12 float values for each month
+                "monthly_wb_range_50": [],  # list of 12 float values for each month
+                "monthly_db_100": [],  # list of 12 float values for each month
+                "monthly_wb_100": [],  # list of 12 float values for each month
+                "monthly_db_20": [],  # list of 12 float values for each month
+                "monthly_wb_20": [],  # list of 12 float values for each month
+                "monthly_db_04": [],  # list of 12 float values for each month
+                "monthly_wb_04": [],  # list of 12 float values for each month
+                "monthly_wind": [],  # list of 12 float values for each month
+                "monthly_wind_dirs": [],  # matrix with 12 cols for months of the year
+                                          #and 8 rows for the cardinal directions.
+                "standard_pressure_at_elev": 0.0,  # float value for pressure in Pa
+                "monthly_tau_beam":[],  # list of 12 float values for each month
+                "monthly_tau_diffuse": []  # list of 12 float values for each month
                 }
         """
         # Initialize the class with all data missing

--- a/ladybug/stat.py
+++ b/ladybug/stat.py
@@ -130,8 +130,8 @@ class STAT(object):
 
                 {
                 "location": {},  # ladybug location schema
-                "ashrae_climate_zone": "",  # str
-                "koppen_climate_zone": "", # str
+                "ashrae_climate_zone": ""5A,  # str
+                "koppen_climate_zone": "Dfa", # str
                 "extreme_cold_week": {},  # ladybug analysis period schema
                 "extreme_hot_week": {},  # ladybug analysis period schema
                 "typical_weeks": {},  # dict of ladybug analysis period schemas
@@ -150,7 +150,7 @@ class STAT(object):
                 "monthly_wind": [],  # list of 12 float values for each month
                 "monthly_wind_dirs": [],  # matrix with 12 cols for months of the year
                                           #and 8 rows for the cardinal directions.
-                "standard_pressure_at_elev": 0.0,  # float value for pressure in Pa
+                "standard_pressure_at_elev": 101325,  # float value for pressure in Pa
                 "monthly_tau_beam":[],  # list of 12 float values for each month
                 "monthly_tau_diffuse": []  # list of 12 float values for each month
                 }

--- a/ladybug/sunpath.py
+++ b/ladybug/sunpath.py
@@ -46,7 +46,7 @@ class Sunpath(object):
 
     Usage:
 
-    .. code-block:: json
+    .. code-block:: python
 
         import ladybug.sunpath as sunpath
         # initiate sunpath

--- a/ladybug/sunpath.py
+++ b/ladybug/sunpath.py
@@ -20,10 +20,9 @@ except ImportError as e:
 
 
 class Sunpath(object):
-    """
-    Calculates sun path.
+    """Calculates sun path.
 
-    Attributes:
+    Args:
         latitude: The latitude of the location in degrees. Values must be
             between -90 and 90. Default is set to the equator.
         longitude: The longitude of the location in degrees (Default: 0)
@@ -37,7 +36,17 @@ class Sunpath(object):
         daylight_saving_period: An analysis period for daylight saving.
             (Default: None)
 
+    Properties:
+        * daylight_saving_period
+        * is_leap_year
+        * latitude
+        * longitude
+        * north_angle
+        * time_zone
+
     Usage:
+
+    .. code-block:: json
 
         import ladybug.sunpath as sunpath
         # initiate sunpath
@@ -53,21 +62,6 @@ class Sunpath(object):
     def __init__(self, latitude=0, longitude=0, time_zone=0, north_angle=0,
                  daylight_saving_period=None):
         """Init sunpath.
-
-        Args:
-            latitude: The latitude of the location in degrees. Values must be
-                between -90 and 90. Default is set to the equator.
-            longitude: The longitude of the location in degrees (Default: 0)
-            time_zone: A number representing the time zone of the location you are
-                constructing. This can improve the accuracy of the resulting sun
-                plot.  The time zone should follow the epw convention and should be
-                between -12 and +12, where 0 is at Greenwich, UK, positive values
-                are to the East of Greenwich and negative values are to the West.
-            north_angle: Angle to north (0-360). 90 is west and 270 is east
-                (Default: 0).
-            daylight_saving_period: An analysis period for daylight saving.
-                (Default: None).
-
         """
         self.time_zone = time_zone
         self.latitude = latitude
@@ -520,11 +514,17 @@ class Sunpath(object):
             annual: Set to True to draw an annual sunpath.
                 Otherwise a daily sunpath is drawn.
             rem_night: Remove suns which are under the horizon(night!).
+
         Returns:
-            base_curves: A collection of curves for base plot.
-            analemma_curves: A collection of analemma_curves.
-            daily_curves: A collection of daily_curves.
-            suns: A list of suns.
+            A tuple with four elements
+
+            -   base_curves: A collection of curves for base plot.
+
+            -   analemma_curves: A collection of analemma_curves.
+
+            -   daily_curves: A collection of daily_curves.
+
+            -   suns: A list of suns.
         """
         # check and make sure the call is coming from inside a plus library
         assert ladybug.isplus, \
@@ -593,9 +593,11 @@ class Sunpath(object):
         This is useful for calculating hours of analemma curves.
 
         Returns:
-            -1 if always night,
-            0 if both day and night,
-            1 if always day.
+            One of the following:
+
+            * -1 if always night,
+            * 0 if both day and night,
+            * 1 if always day.
         """
         # check for 21 dec and 21 jun
         low = self.calculate_sun(12, 21, hour).is_during_day
@@ -680,7 +682,7 @@ class Sunpath(object):
 class Sun(object):
     """Sun.
 
-    Attributes:
+    Args:
         datetime: A DateTime that represents the datetime for this sun_vector
         altitude: Solar Altitude in **radians**
         azimuth: Solar Azimuth in **radians**
@@ -690,6 +692,20 @@ class Sun(object):
             for Daylight saving period
         north_angle: North angle of the sunpath in Degrees. This will be only
             used to calculate the solar vector.
+
+    Properties:
+        * datetime
+        * north_angle
+        * hoy
+        * altitude
+        * azimuth
+        * altitude_in_radians
+        * azimuth_in_radians
+        * is_solar_time
+        * is_daylight_saving
+        * data
+        * is_during_day
+        * sun_vector
     """
 
     __slots__ = ('_datetime', '_altitude', '_azimuth', '_is_solar_time',

--- a/ladybug/wea.py
+++ b/ladybug/wea.py
@@ -39,7 +39,7 @@ except ImportError:  # python 3
 class Wea(object):
     """An annual WEA object containing solar irradiance.
 
-    Attributes:
+    Args:
         location: Ladybug location object.
         direct_normal_irradiance: An annual data collection of direct normal irradiance
             values for every timestep of the year.
@@ -49,6 +49,18 @@ class Wea(object):
             Default is 1 for one value per hour.
         is_leap_year: A boolean to indicate if values are representing a leap year.
             Default is False.
+
+    Properties:
+        * datetimes
+        * direct_normal_irradiance
+        * diffuse_horizontal_irradiance
+        * direct_horizontal_irradiance
+        * global_horizontal_irradiance
+        * header
+        * hoys
+        * isWea
+        * timestep
+        * is_leap_year
     """
 
     def __init__(self, location, direct_normal_irradiance,
@@ -104,13 +116,18 @@ class Wea(object):
         """ Create Wea from a dictionary
 
         Args:
-            data: {
+            data: A python dictionary in the following format
+
+        .. code-block:: json
+
+            {
             "location": {} , // ladybug location schema
             "direct_normal_irradiance": [], // List of hourly direct normal
                 irradiance data points
             "diffuse_horizontal_irradiance": [], // List of hourly diffuse
                 horizontal irradiance data points
-            "timestep": float //timestep between measurements, default is 1}
+            "timestep": float //timestep between measurements, default is 1
+            }
         """
         required_keys = ('location', 'direct_normal_irradiance',
                          'diffuse_horizontal_irradiance')
@@ -582,16 +599,16 @@ class Wea(object):
             ground_reflectance: A number between 0 and 1 that represents the
                 reflectance of the ground. Default is set to 0.2. Some
                 common ground reflectances are:
-                    urban: 0.18
-                    grass: 0.20
-                    fresh grass: 0.26
-                    soil: 0.17
-                    sand: 0.40
-                    snow: 0.65
-                    fresh_snow: 0.75
-                    asphalt: 0.12
-                    concrete: 0.30
-                    sea: 0.06
+                *   urban: 0.18
+                *   grass: 0.20
+                *   fresh grass: 0.26
+                *   soil: 0.17
+                *   sand: 0.40
+                *   snow: 0.65
+                *   fresh_snow: 0.75
+                *   asphalt: 0.12
+                *   concrete: 0.30
+                *   sea: 0.06
             isotrophic: A boolean value that sets whether an isotropic sky is
                 used (as opposed to an anisotropic sky). An isotrophic sky
                 assumes an even distribution of diffuse irradiance across the
@@ -599,10 +616,16 @@ class Wea(object):
                 near the solar disc. Default is set to True for isotrophic
 
         Returns:
-            total_irradiance: A data collection of total solar irradiance.
-            direct_irradiance: A data collection of direct solar irradiance.
-            diffuse_irradiance: A data collection of diffuse sky solar irradiance.
-            reflected_irradiance: A data collection of ground reflected solar irradiance.
+            A tuple of four elements
+
+            -   total_irradiance: A data collection of total solar irradiance.
+
+            -   direct_irradiance: A data collection of direct solar irradiance.
+
+            -   diffuse_irradiance: A data collection of diffuse sky solar irradiance.
+
+            -   reflected_irradiance: A data collection of ground reflected solar
+                irradiance.
         """
         # function to convert polar coordinates to xyz.
         def pol2cart(phi, theta):
@@ -685,11 +708,17 @@ class Wea(object):
                 or lack of a leap year must align with this Wea.
 
         Returns:
-            global_horiz_ill: Data collection of Global Horizontal Illuminance in lux.
-            direct_normal_ill: Data collection of Direct Normal Illuminance in lux.
-            diffuse_horizontal_ill: Data collection of  Diffuse Horizontal Illuminance
+            A tuple with four elements
+
+            -   global_horiz_ill: Data collection of Global Horizontal Illuminance
                 in lux.
-            zenith_lum: Data collection of Zenith Luminance in lux.
+
+            -   direct_normal_ill: Data collection of Direct Normal Illuminance in lux.
+
+            -   diffuse_horizontal_ill: Data collection of  Diffuse Horizontal
+                Illuminance in lux.
+
+            -   zenith_lum: Data collection of Zenith Luminance in lux.
         """
         # check the dew_point input
         assert len(dew_point) == self.hour_count(self.is_leap_year) * self.timestep, \

--- a/ladybug/wea.py
+++ b/ladybug/wea.py
@@ -58,7 +58,6 @@ class Wea(object):
         * global_horizontal_irradiance
         * header
         * hoys
-        * isWea
         * timestep
         * is_leap_year
     """

--- a/ladybug/wea.py
+++ b/ladybug/wea.py
@@ -118,15 +118,15 @@ class Wea(object):
         Args:
             data: A python dictionary in the following format
 
-        .. code-block:: json
+        .. code-block:: python
 
             {
-            "location": {} , // ladybug location schema
-            "direct_normal_irradiance": [], // List of hourly direct normal
-                irradiance data points
-            "diffuse_horizontal_irradiance": [], // List of hourly diffuse
-                horizontal irradiance data points
-            "timestep": float //timestep between measurements, default is 1
+            "location": {} ,  # ladybug location schema
+            "direct_normal_irradiance": [],  # List of hourly direct normal
+                                             # irradiance data points
+            "diffuse_horizontal_irradiance": [],  # List of hourly diffuse
+                                                  # horizontal irradiance data points
+            "timestep": 1.0  # timestep between measurements, default is 1
             }
         """
         required_keys = ('location', 'direct_normal_irradiance',

--- a/ladybug/wea.py
+++ b/ladybug/wea.py
@@ -121,7 +121,7 @@ class Wea(object):
         .. code-block:: python
 
             {
-            "location": {} ,  # ladybug location schema
+            "location": {},  # ladybug location schema
             "direct_normal_irradiance": [],  # List of hourly direct normal
                                              # irradiance data points
             "diffuse_horizontal_irradiance": [],  # List of hourly diffuse


### PR DESCRIPTION
@chriswmackey @mostaphaRoudsari @theo-armour 
Took a while but I finally completed a first pass on the entire package. I fixed many display/formatting issues but a few things remain. If you have time read on, help is appreciated.

1a)
to_dict() method:
Throughout the package, in many from_dict methods, the docstring shows the dictionary with the description of the keys, this makes sphinx to invalidate it as  json code. 
Could possibly solve it in a number of different ways, just a couple :
a) Not using json block and use a literal or shell block.
b) As shown in ladybug.analysisperiod.AnalysisPeriod: writing the dictionary with default values only and listing the keys outside of the dictionary.

1b) 
Many from_dict() cases fail to be detected as json given the differences between dictionaries and json formats:
Python uses single and double quotes for string literals. JSON only allows double quotes.
Tuples not supported in JSON
Python uses None objects, JSON uses null to as a special "doesn't exist" sentinel value.
Python uses True and False as boolean values, JSON uses true and false.
Python dictionary keys can be any hashable type, JSON only supports strings.
Do we JSONize the python dictionaries or we specify the block as something else(ex. code).

2)
In many classes I added properties when missing. In some classes  Properties / Arguments that listed _init_ inputs were renamed as Args before adding the properties. 
Do we add descriptions to the properties?  We have inconsistency at this point, sometimes in Arguments we have descriptions but not in properties (sometimes are the same, more often than not they differ)

3)
Usage - Is correct to use a literal block for these? Should title be bolded?

4)
Are constants displayed correctly? Right now contents are shown bolded, in some modules they extend multiple lines (ex. ladybug.epw.EPW.FIELDS)


6) 
In Class properties where descriptions extend multiple lines (ex. ladybug.analysisperiod.AnalysisPeriod)  lines 2 and beyond display incorrectly once the property name is made bolded. We actually have this issue in one instance in ladybug.geometry(geometry3d.arc for reference). After trying to solve this in the docstring itself, the only way I seem to find a workaround was by joining these multi-line descriptions in one single line. This was done at the  autodoc_process_docstring by adding a new function, make_properties_one_liner, to execute before make_fields_bolded. I may find a way to simplify this routine but seems to be doing the job well at this point. 
If you think there is a simpler way to tackle this issue feel free to pitch in, any comments is appreciated.
 
7) 
Minor observations - not documentation related:
ladybug.datacollection.HourlyContinuousCollection: Has is_continuous and isContinuous properties

VolumeFlowRate:
Shouldn't isFlowRate property be isVolumeFlowRate? 