### PR TITLE
Enabling the ability for DateTime to be pickled and unpickled

### DIFF
--- a/ladybug/dt.py
+++ b/ladybug/dt.py
@@ -46,6 +46,9 @@ class DateTime(datetime):
                 e, month, day, hour, minute
             ))
 
+    def __reduce_ex__(self, protocol):
+        return (type(self), (self.month, self.day, self.hour, self.minute))
+
     @classmethod
     def from_dict(cls, data):
         """Creat datetime from a dictionary.
@@ -293,6 +296,9 @@ class Date(date):
         except ValueError as e:
             raise ValueError("{}:\n\t({}/{})(m/d)".format(e, month, day))
 
+    def __reduce_ex__(self, protocol):
+        return (type(self), (self.month, self.day, self.leap_year))
+
     @classmethod
     def from_dict(cls, data):
         """Create date from a dictionary.
@@ -426,6 +432,8 @@ class Time(time):
             return time.__new__(cls, hour, minute)
         except ValueError as e:
             raise ValueError("{}:\n\t({}:{})(h:m)".format(e, hour, minute))
+    def __reduce_ex__(self, protocol):
+        return (type(self), (self.hour, self.minute))
 
     @classmethod
     def from_dict(cls, data):

--- a/ladybug/dt.py
+++ b/ladybug/dt.py
@@ -47,6 +47,9 @@ class DateTime(datetime):
             ))
 
     def __reduce_ex__(self, protocol):
+        """This will make the __new__() constructor to be called when the class instance is unpickled by the pickle.loads() call.
+        This hidden method is necessary for pickle to work
+        """
         return (type(self), (self.month, self.day, self.hour, self.minute))
 
     @classmethod
@@ -297,6 +300,9 @@ class Date(date):
             raise ValueError("{}:\n\t({}/{})(m/d)".format(e, month, day))
 
     def __reduce_ex__(self, protocol):
+        """This will make the __new__() constructor to be called when the class instance is unpickled by the pickle.loads() call.
+        This hidden method is necessary for pickle to work
+        """
         return (type(self), (self.month, self.day, self.leap_year))
 
     @classmethod
@@ -432,7 +438,11 @@ class Time(time):
             return time.__new__(cls, hour, minute)
         except ValueError as e:
             raise ValueError("{}:\n\t({}:{})(h:m)".format(e, hour, minute))
+
     def __reduce_ex__(self, protocol):
+        """This will make the __new__() constructor to be called when the class instance is unpickled by the pickle.loads() call.
+        This hidden method is necessary for pickle to work
+        """
         return (type(self), (self.hour, self.minute))
 
     @classmethod

--- a/tests/dt_test.py
+++ b/tests/dt_test.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 from ladybug.dt import DateTime, Date, Time
+import pickle
 
 
 def test_date_time_init():
@@ -195,3 +196,18 @@ def test_time_to_from_array():
     rebuilt_t = Time.from_array(t_arr)
     assert rebuilt_t == t1
     assert rebuilt_t.to_array() == t_arr
+
+
+def test_pickle_and_unpickle():
+    """Test the pickling and unpickling of DateTime, Date, and Time objects."""
+    dt1 = DateTime(6, 21, 12)
+    dt2 = Date(6, 21)
+    dt3 = Time(12, 30)
+
+    serialized_dt1 = pickle.dumps(dt1)
+    serialized_dt2 = pickle.dumps(dt2)
+    serialized_dt3 = pickle.dumps(dt3)
+
+    assert pickle.loads(serialized_dt1) == dt1
+    assert pickle.loads(serialized_dt2) == dt2
+    assert pickle.loads(serialized_dt3) == dt3


### PR DESCRIPTION
Changes are made to enable the `DateTime`, `Date`, and `Time` to be pickled and unpickled. Also referencing  ladybug-tools#188