### PR TITLE
style(pep8): Remove all `is True` and `is False` cases

### DIFF
--- a/ladybug/_datacollectionbase.py
+++ b/ladybug/_datacollectionbase.py
@@ -356,7 +356,7 @@ class BaseCollection(object):
         else:
             if self._enumeration is None:
                 self._get_mutable_enumeration()
-            if mutable is False:
+            if not mutable:
                 col_obj = self._enumeration['immutable'][self._collection_type]
             else:
                 col_obj = self._enumeration['mutable'][self._collection_type]
@@ -456,7 +456,7 @@ class BaseCollection(object):
             first_coll = data_collections[0]
             for coll in data_collections[1:]:
                 if not first_coll.is_collection_aligned(coll):
-                    if raise_exception is True:
+                    if raise_exception:
                         error_msg = '{} Data Collection is not aligned with '\
                             '{} Data Collection.'.format(
                                 first_coll.header.data_type, coll.header.data_type)
@@ -666,7 +666,7 @@ class BaseCollection(object):
     def _get_mutable_enumeration(self):
         self._enumeration = {'mutable': {}, 'immutable': {}}
         for clss in self._all_subclasses(BaseCollection):
-            if clss._mutable is True:
+            if clss._mutable:
                 self._enumeration['mutable'][clss._collection_type] = clss
             else:
                 self._enumeration['immutable'][clss._collection_type] = clss

--- a/ladybug/color.py
+++ b/ladybug/color.py
@@ -390,7 +390,7 @@ class ColorRange(object):
         continuous_colors: Boolean. If True, the colors generated from the
             color range will be in a continuous gradient. If False,
             they will be categorized in incremental groups according to the
-            number_of_segments. Default is True for continuous colors.
+            number_of_segments. Default: True for continuous colors.
 
     Properties:
         * colors

--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -282,7 +282,7 @@ class HourlyDiscontinuousCollection(BaseCollection):
             linear interpolation.
         """
         # validate analysis_period and use the resulting period to generate datetimes
-        assert self.validated_a_period is True, 'validated_a_period property must be' \
+        assert self.validated_a_period, 'validated_a_period property must be' \
             ' True to use interpolate_holes(). Run validate_analysis_period().'
         mins_per_step = int(60 / self.header.analysis_period.timestep)
         new_datetimes = self.header.analysis_period.datetimes
@@ -419,7 +419,7 @@ class HourlyDiscontinuousCollection(BaseCollection):
                 n_ap[6] = int(60 / mins_per_step)
 
         # check that the analysis_period leap_year is correct.
-        if a_per.is_leap_year is False:
+        if not a_per.is_leap_year:
             for date_t in sort_datetimes:
                 if date_t.month == 2 and date_t.day == 29:
                     n_ap[7] = True
@@ -655,12 +655,12 @@ class HourlyContinuousCollection(HourlyDiscontinuousCollection):
 
         # divide cumulative values by the timestep
         native_cumulative = self.header.data_type.cumulative
-        if cumulative is True or (cumulative is None and native_cumulative):
+        if cumulative or (cumulative is None and native_cumulative):
             for i, d in enumerate(_new_values):
                 _new_values[i] = d / timestep
 
         # shift data by a half-hour if data is averaged or cumulative over an hour
-        if self.header.data_type.point_in_time is False:
+        if not self.header.data_type.point_in_time:
             shift_dist = int(timestep / 2)
             _new_values = _new_values[-shift_dist:] + _new_values[:-shift_dist]
 
@@ -763,10 +763,10 @@ class HourlyContinuousCollection(HourlyDiscontinuousCollection):
         """
         t_s = 60 / self.header.analysis_period.timestep
         st_ind = self.header.analysis_period.st_time.moy / t_s
-        if self.header.analysis_period.is_reversed is False:
+        if not self.header.analysis_period.is_reversed:
             _filt_indices = [int(moy / t_s - st_ind) for moy in moys]
         else:
-            if self.header.analysis_period.is_leap_year is False:
+            if not self.header.analysis_period.is_leap_year:
                 eoy_ind = 8759 * self.header.analysis_period.timestep - st_ind
             else:
                 eoy_ind = 8783 * self.header.analysis_period.timestep - st_ind
@@ -881,7 +881,7 @@ class HourlyContinuousCollection(HourlyDiscontinuousCollection):
         else:
             if self._enumeration is None:
                 self._get_mutable_enumeration()
-            if mutable is False:
+            if not mutable:
                 col_obj = self._enumeration['immutable'][self._collection_type]
             else:
                 col_obj = self._enumeration['mutable'][self._collection_type]
@@ -954,10 +954,9 @@ class HourlyContinuousCollection(HourlyDiscontinuousCollection):
             n_ap[3] = self.header.analysis_period.end_month
             n_ap[4] = self.header.analysis_period.end_day
             new_needed = True
-        if new_needed is False:
+        if not new_needed:
             return a_per
-        else:
-            return AnalysisPeriod(*n_ap)
+        return AnalysisPeriod(*n_ap)
 
     def _check_values(self, values):
         """Check values whenever they come through the values setter."""
@@ -966,7 +965,7 @@ class HourlyContinuousCollection(HourlyDiscontinuousCollection):
             'values should be a list or tuple. Got {}'.format(type(values))
         if self.header.analysis_period.is_annual:
             a_period_len = 8760 * self.header.analysis_period.timestep
-            if self.header.analysis_period.is_leap_year is True:
+            if self.header.analysis_period.is_leap_year:
                 a_period_len = a_period_len + 24 * self.header.analysis_period.timestep
         else:
             a_period_len = len(self.header.analysis_period.moys)
@@ -1118,7 +1117,7 @@ class DailyCollection(BaseCollection):
                 a_per.end_day, a_per.end_hour, a_per.timestep, a_per.is_leap_year]
 
         # check that the analysis_period leap_year is correct.
-        if a_per.is_leap_year is False:
+        if not a_per.is_leap_year:
             for date_t in self.datetimes:
                 if date_t == 366:
                     n_ap[7] = True
@@ -1203,7 +1202,7 @@ class DailyCollection(BaseCollection):
     @property
     def is_continuous(self):
         """Boolean denoting whether the data collection is continuous."""
-        if self._validated_a_period is True and \
+        if self._validated_a_period and \
                 len(self.values) == len(self.header.analysis_period.doys_int):
             return True
         else:
@@ -1353,7 +1352,7 @@ class MonthlyCollection(BaseCollection):
     @property
     def is_continuous(self):
         """Boolean denoting whether the data collection is continuous."""
-        if self._validated_a_period is True and \
+        if self._validated_a_period and \
                 len(self.values) == len(self.header.analysis_period.months_int):
             return True
         else:
@@ -1518,7 +1517,7 @@ class MonthlyPerHourCollection(BaseCollection):
     def is_continuous(self):
         """Boolean denoting whether the data collection is continuous."""
         a_per = self.header.analysis_period
-        if self._validated_a_period is True and a_per.st_hour == 0 and a_per.end_hour \
+        if self._validated_a_period and a_per.st_hour == 0 and a_per.end_hour \
                 == 23 and len(self.values) == len(a_per.months_per_hour):
             return True
         else:

--- a/ladybug/datatype/base.py
+++ b/ladybug/datatype/base.py
@@ -89,8 +89,7 @@ class DataTypeBase(object):
             raise_exception: Set to True to raise an exception if not acceptable.
         """
         _is_acceptable = unit in self.units
-
-        if _is_acceptable or raise_exception is False:
+        if _is_acceptable or not raise_exception:
             return _is_acceptable
         else:
             raise ValueError(
@@ -316,7 +315,7 @@ class _DataTypeEnumeration(object):
     _GENERICTYPE = None
 
     def __init__(self, import_modules=True):
-        if import_modules is True:
+        if import_modules:
             self._import_modules()
 
         for clss in DataTypeBase.__subclasses__():

--- a/ladybug/datatype/generic.py
+++ b/ladybug/datatype/generic.py
@@ -50,8 +50,8 @@ class GenericType(DataTypeBase):
             'boolean. Got {}.'.format(type(point_in_time))
         assert isinstance(cumulative, bool), 'cumulative must be a ' \
             'boolean. Got {}.'.format(type(cumulative))
-        if point_in_time is True:
-            assert cumulative is False, 'cumulative cannot be True when ' \
+        if point_in_time:
+            assert not cumulative, 'cumulative cannot be True when ' \
                 'point_in_time is also True.'
 
         self._name = name

--- a/ladybug/designday.py
+++ b/ladybug/designday.py
@@ -274,8 +274,8 @@ class DesignDay(object):
                 creation of the humidity condition. Default is 101325 Pa
                 for pressure at sea level.
         """
-        db_key = 'DB996' if use_990 is False else 'DB990'
-        perc_str = '99.6' if use_990 is False else '99.0'
+        db_key = 'DB996' if not use_990 else 'DB990'
+        perc_str = '99.6' if not use_990 else '99.0'
         pressure = pressure if pressure is not None else 101325
         db_cond = DryBulbCondition(float(ashrae_dict[db_key]), 0)
         hu_cond = HumidityCondition('Wetbulb', float(ashrae_dict[db_key]), pressure)
@@ -308,9 +308,9 @@ class DesignDay(object):
                 and the second is for the tau diffuse value.  Default is
                 None, which will default to the original ASHRAE Clear Sky.
         """
-        db_key = 'DB004' if use_010 is False else 'DB010'
-        wb_key = 'WB_DB004' if use_010 is False else 'WB_DB010'
-        perc_str = '0.4' if use_010 is False else '1.0'
+        db_key = 'DB004' if not use_010 else 'DB010'
+        wb_key = 'WB_DB004' if not use_010 else 'WB_DB010'
+        perc_str = '0.4' if not use_010 else '1.0'
         pressure = pressure if pressure is not None else 101325
         db_cond = DryBulbCondition(float(ashrae_dict[db_key]), float(ashrae_dict['DBR']))
         hu_cond = HumidityCondition('Wetbulb', float(ashrae_dict[wb_key]), pressure)

--- a/ladybug/epw.py
+++ b/ladybug/epw.py
@@ -338,7 +338,7 @@ class EPW(object):
     def annual_heating_design_day_996(self):
         """A design day object representing the annual 99.6% heating design day."""
         self._load_header_check()
-        if bool(self._heating_dict) is True:
+        if bool(self._heating_dict):
             avg_press = self.atmospheric_station_pressure.average
             avg_press = None if avg_press == 999999 else avg_press
             return DesignDay.from_ashrae_dict_heating(
@@ -350,7 +350,7 @@ class EPW(object):
     def annual_heating_design_day_990(self):
         """A design day object representing the annual 99.0% heating design day."""
         self._load_header_check()
-        if bool(self._heating_dict) is True:
+        if bool(self._heating_dict):
             avg_press = self.atmospheric_station_pressure.average
             avg_press = None if avg_press == 999999 else avg_press
             return DesignDay.from_ashrae_dict_heating(
@@ -362,7 +362,7 @@ class EPW(object):
     def annual_cooling_design_day_004(self):
         """A design day object representing the annual 0.4% cooling design day."""
         self._load_header_check()
-        if bool(self._cooling_dict) is True:
+        if bool(self._cooling_dict):
             avg_press = self.atmospheric_station_pressure.average
             avg_press = None if avg_press == 999999 else avg_press
             return DesignDay.from_ashrae_dict_cooling(
@@ -374,7 +374,7 @@ class EPW(object):
     def annual_cooling_design_day_010(self):
         """A design day object representing the annual 1.0% cooling design day."""
         self._load_header_check()
-        if bool(self._cooling_dict) is True:
+        if bool(self._cooling_dict):
             avg_press = self.atmospheric_station_pressure.average
             avg_press = None if avg_press == 999999 else avg_press
             return DesignDay.from_ashrae_dict_cooling(
@@ -472,7 +472,7 @@ class EPW(object):
         self._load_header_check()
         assert isinstance(data, dict), 'monthly_ground_temperature' \
             ' must be an OrderedDict. Got {}.'.format(type(data))
-        if bool(data) is True:
+        if bool(data):
             for val in data.values():
                 assert isinstance(val, MonthlyCollection), 'monthly_ground_temperature' \
                     ' must contain MonthlyCollection objects. Got {}.'.format(type(val))
@@ -493,7 +493,7 @@ class EPW(object):
         """Check if an input design condition dictionary is acceptable."""
         assert isinstance(des_dict, dict), '{}' \
             ' must be a dictionary. Got {}.'.format(cond_name, type(des_dict))
-        if bool(des_dict) is True:
+        if bool(des_dict):
             input_keys = list(des_dict.keys())
             for key in req_keys:
                 assert key in input_keys, 'Required key "{}" was not found in ' \
@@ -503,7 +503,7 @@ class EPW(object):
         """Check if input for the typical/extreme weeks of the header is correct."""
         assert isinstance(data, dict), '{}' \
             ' must be an OrderedDict. Got {}.'.format(week_type, type(data))
-        if bool(data) is True:
+        if bool(data):
             for val in data.values():
                 assert isinstance(val, AnalysisPeriod), '{} dictionary must contain' \
                     ' AnalysisPeriod objects. Got {}.'.format(week_type, type(val))
@@ -621,7 +621,7 @@ class EPW(object):
                 return
 
             # read first line of data to overwrite the number of fields
-            if original_header_load is True:
+            if original_header_load:
                 for i in xrange(7):
                     epwin.readline()
             line = epwin.readline()
@@ -661,7 +661,7 @@ class EPW(object):
             # if the first value is at 1 AM, move last item to start position
             for field_number in xrange(self._num_of_fields):
                 point_in_time = headers[field_number].data_type.point_in_time
-                if point_in_time is True:
+                if point_in_time:
                     # move the last hour to first position
                     last_hour = self._data[field_number].pop()
                     self._data[field_number].insert(0, last_hour)
@@ -692,7 +692,7 @@ class EPW(object):
         else:
             des_str = 'DESIGN CONDITIONS,0\n'
         weeks = []
-        if bool(self.extreme_hot_weeks) is True:
+        if bool(self.extreme_hot_weeks):
             for wk_name, a_per in self.extreme_hot_weeks.items():
                 weeks.append(self._format_week(wk_name, 'Extreme', a_per))
         if bool(self.extreme_cold_weeks):
@@ -708,7 +708,7 @@ class EPW(object):
             grnd_st = grnd_st + ',{},{}'.format(
                 depth, self._format_grndt(self._monthly_ground_temps[depth]))
         grnd_st = grnd_st + '\n'
-        leap_yr = 'Yes' if self._is_leap_year is True else 'No'
+        leap_yr = 'Yes' if self._is_leap_year else 'No'
         leap_str = 'HOLIDAYS/DAYLIGHT SAVINGS,{},{},{},0\n'.format(
             leap_yr, self.daylight_savings_start, self.daylight_savings_end)
         c_str1 = 'COMMENTS 1,{}\n'.format(self.comments_1)
@@ -740,7 +740,7 @@ class EPW(object):
         if not self.is_data_loaded:
             self._import_data()
         originally_ip = False
-        if self.is_ip is True:
+        if self.is_ip:
             self.convert_to_si()
             originally_ip = True
 
@@ -750,7 +750,7 @@ class EPW(object):
             # if the first value is at 1AM, move first item to end position
             for field in xrange(0, self._num_of_fields):
                 point_in_time = self._data[field].header.data_type.point_in_time
-                if point_in_time is True:
+                if point_in_time:
                     first_hour = self._data[field]._values.pop(0)
                     self._data[field]._values.append(first_hour)
 
@@ -773,11 +773,11 @@ class EPW(object):
             # move last item to start position for fields on the hour
             for field in xrange(0, self._num_of_fields):
                 point_in_time = self._data[field].header.data_type.point_in_time
-                if point_in_time is True:
+                if point_in_time:
                     last_hour = self._data[field]._values.pop()
                     self._data[field]._values.insert(0, last_hour)
 
-        if originally_ip is True:
+        if originally_ip:
             self.convert_to_ip()
 
         return file_path
@@ -789,7 +789,7 @@ class EPW(object):
         EPW should be in Imperial units."""
         if not self.is_data_loaded:
             self._import_data()
-        if self.is_ip is False:
+        if not self.is_ip:
             for coll in self._data:
                 coll.convert_to_ip()
         self._is_ip = True
@@ -802,7 +802,7 @@ class EPW(object):
         from EPW data."""
         if not self.is_data_loaded:
             self._import_data()
-        if self.is_ip is True:
+        if self.is_ip:
             for coll in self._data:
                 coll.convert_to_si()
         self._is_ip = False
@@ -1326,7 +1326,7 @@ pdfs/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
             file_path += '.wea'
 
         originally_ip = False
-        if self.is_ip is True:
+        if self.is_ip:
             self.convert_to_si()
             originally_ip = True
 
@@ -1347,7 +1347,7 @@ pdfs/pdfs_v8.4.0/AuxiliaryPrograms.pdf (Chapter 2.9.1)
         file_data = ''.join(lines)
         write_to_file(file_path, file_data, True)
 
-        if originally_ip is True:
+        if originally_ip:
             self.convert_to_ip()
 
         return file_path

--- a/ladybug/graphic.py
+++ b/ladybug/graphic.py
@@ -62,15 +62,15 @@ class GraphicContainer(object):
                 unit = data_type.units[0] if unit is None else unit
                 data_type.is_unit_acceptable(unit)
                 self.legend_parameters.title = unit if \
-                    self.legend_parameters.vertical is True \
+                    self.legend_parameters.vertical \
                     else '{} ({})'.format(data_type.name, unit)
             if data_type.unit_descr is not None and \
                     self.legend_parameters.ordinal_dictionary is None:
                 self.legend_parameters.ordinal_dictionary = data_type.unit_descr
                 sorted_keys = sorted(data_type.unit_descr.keys())
-                if self.legend.is_min_default is True:
+                if self.legend.is_min_default:
                     self.legend_parameters.min = sorted_keys[0]
-                if self.legend.is_max_default is True:
+                if self.legend.is_max_default:
                     self.legend_parameters.max = sorted_keys[-1]
                 if self.legend_parameters.is_segment_count_default:
                     try:  # try to set the number of segments to align with ordinal text

--- a/ladybug/legend.py
+++ b/ladybug/legend.py
@@ -314,7 +314,7 @@ class Legend(object):
         """Point2D for the title in the 2D space of the legend."""
         _l_par = self.legend_parameters
         if _l_par.vertical:
-            offset = 0.5 if self.legend_parameters.continuous_legend is True else 0.25
+            offset = 0.5 if self.legend_parameters.continuous_legend else 0.25
             return Point2D(0, _l_par.segment_height * (self.segment_length + offset))
         else:
             return Point2D(-_l_par.segment_width * self.segment_length,
@@ -616,7 +616,7 @@ class LegendParameters(object):
 
         If True, the colors generated from the corresponding legend will be in a
         continuous gradient. If False, they will be categorized in incremental
-        groups according to the segment_count. Default is True for continuous colors.
+        groups according to the segment_count. Default: True for continuous colors.
         """
         return self._continuous_colors
 
@@ -636,7 +636,7 @@ class LegendParameters(object):
         If True, the legend mesh will be drawn vertex-by-vertex resulting in a
         continuous gradient instead of discrete segments. If False, the mesh will be
         generated with one face for each of the segment_counts.
-        Default is False for depicting discrete categories.
+        Default: False for depicting discrete categories.
         """
         return self._continuous_legend
 
@@ -712,7 +712,7 @@ class LegendParameters(object):
     def include_larger_smaller(self):
         """Boolean noting whether > and < should be included in legend segment text.
 
-         Default is False.
+         Default: False.
          """
         return self._include_larger_smaller
 
@@ -724,7 +724,7 @@ class LegendParameters(object):
     def vertical(self):
         """Boolean noting whether legend is vertical (True) of horizontal (False).
 
-        Default is True for a vertically-oriented legend.
+        Default: True for a vertically-oriented legend.
         """
         return self._vertical
 

--- a/ladybug/skymodel.py
+++ b/ladybug/skymodel.py
@@ -98,7 +98,7 @@ def ashrae_revised_clear_sky(altitudes, tb, td, use_2017_model=False):
     dir_norm_rad = []
     dif_horiz_rad = []
 
-    if use_2017_model is True:
+    if use_2017_model:
         ab = 1.454 - (0.406 * tb) - (0.268 * td) - (0.021 * tb * td)
         ad = 0.507 + (0.205 * tb) - (0.080 * td) - (0.190 * tb * td)
     else:
@@ -197,7 +197,7 @@ def zhang_huang_solar_split(altitudes, doys, cloud_cover, relative_humidity,
         atm_pressure: A list of float values that represent the
             atmospheric pressure in Pa.
         use_disc: Set to True to use the original DISC model as opposed to the
-            newer and more accurate DIRINT model. Default is False.
+            newer and more accurate DIRINT model. Default: False.
 
     Returns:
         A tuple with two elements
@@ -215,7 +215,7 @@ def zhang_huang_solar_split(altitudes, doys, cloud_cover, relative_humidity,
                                 dry_bulb_present[i], dry_bulb_t3_hrs[i], wind_speed[i])
         glob_ir.append(ghi)
 
-    if use_disc is False:
+    if not use_disc:
         # Calculate dew point temperature to improve the splitting of direct + diffuse
         temp_dew = [dew_point_from_db_rh(dry_bulb_present[i], relative_humidity[i])
                     for i in xrange(len(glob_ir))]
@@ -517,7 +517,7 @@ def dirint(ghi, altitudes, doys, pressures, use_delta_kt_prime=True,
         disc_dni.append(dni)
 
     # calculate delta_kt_prime values
-    if use_delta_kt_prime is True:
+    if use_delta_kt_prime:
         delta_kt_prime = []
         for i in xrange(len(kt_primes)):
             try:

--- a/ladybug/stat.py
+++ b/ladybug/stat.py
@@ -467,7 +467,7 @@ class STAT(object):
     @property
     def annual_heating_design_day_996(self):
         """A design day object representing the annual 99.6% heating design day."""
-        if bool(self._winter_des_day_dict) is True:
+        if bool(self._winter_des_day_dict):
             return DesignDay.from_ashrae_dict_heating(
                 self._winter_des_day_dict, self.location, False,
                 self._stand_press_at_elev)
@@ -477,7 +477,7 @@ class STAT(object):
     @property
     def annual_heating_design_day_990(self):
         """A design day object representing the annual 99.0% heating design day."""
-        if bool(self._winter_des_day_dict) is True:
+        if bool(self._winter_des_day_dict):
             return DesignDay.from_ashrae_dict_heating(
                 self._winter_des_day_dict, self.location, True,
                 self._stand_press_at_elev)
@@ -487,7 +487,7 @@ class STAT(object):
     @property
     def annual_cooling_design_day_004(self):
         """A design day object representing the annual 0.4% cooling design day."""
-        if bool(self._summer_des_day_dict) is True:
+        if bool(self._summer_des_day_dict):
             tau = None
             month_num = int(self._summer_des_day_dict['Month'])
             if self._monthly_tau_beam != [] and self._monthly_tau_diffuse != [] \
@@ -504,7 +504,7 @@ class STAT(object):
     @property
     def annual_cooling_design_day_010(self):
         """A design day object representing the annual 1.0% cooling design day."""
-        if bool(self._summer_des_day_dict) is True:
+        if bool(self._summer_des_day_dict):
             tau = None
             month_num = int(self._summer_des_day_dict['Month'])
             if self._monthly_tau_beam != [] and self._monthly_tau_diffuse != [] \
@@ -521,7 +521,7 @@ class STAT(object):
     @property
     def monthly_cooling_design_days_050(self):
         """A list of 12 objects representing monthly 5.0% cooling design days."""
-        if self.monthly_found is False or self._monthly_db_50 == [] \
+        if not self.monthly_found or self._monthly_db_50 == [] \
                 or self._monthly_wb_50 == []:
             return []
         else:
@@ -540,7 +540,7 @@ class STAT(object):
     @property
     def monthly_cooling_design_days_100(self):
         """A list of 12 objects representing monthly 10.0% cooling design days."""
-        if self.monthly_found is False or self._monthly_db_100 == [] \
+        if not self.monthly_found or self._monthly_db_100 == [] \
                 or self._monthly_wb_100 == []:
             return []
         else:
@@ -559,7 +559,7 @@ class STAT(object):
     @property
     def monthly_cooling_design_days_020(self):
         """A list of 12 objects representing monthly 2.0% cooling design days."""
-        if self.monthly_found is False or self._monthly_db_20 == [] \
+        if not self.monthly_found or self._monthly_db_20 == [] \
                 or self._monthly_wb_20 == []:
             return []
         else:
@@ -578,7 +578,7 @@ class STAT(object):
     @property
     def monthly_cooling_design_days_004(self):
         """A list of 12 objects representing monthly 0.4% cooling design days."""
-        if self.monthly_found is False or self._monthly_db_04 == [] \
+        if not self.monthly_found or self._monthly_db_04 == [] \
                 or self._monthly_wb_04 == []:
             return []
         else:

--- a/ladybug/wea.py
+++ b/ladybug/wea.py
@@ -49,7 +49,7 @@ class Wea(object):
         timestep: An integer to set the number of time steps per hour.
             Default is 1 for one value per hour.
         is_leap_year: A boolean to indicate if values are representing a leap year.
-            Default is False.
+            Default: False.
 
     Properties:
         * datetimes
@@ -161,7 +161,7 @@ class Wea(object):
                 Default is 1 for one value per hour. If the wea file has a time step
                 smaller than an hour adjust this input accordingly.
             is_leap_year: A boolean to indicate if values are representing a leap year.
-                Default is False.
+                Default: False.
         """
         assert os.path.isfile(wea_file), 'Failed to find {}'.format(wea_file)
         location = Location()
@@ -241,7 +241,7 @@ class Wea(object):
             timestep: An optional integer to set the number of time steps per
                 hour. Default is 1 for one value per hour.
             is_leap_year: A boolean to indicate if values are representing a leap year.
-                Default is False.
+                Default: False.
         """
         stat = STAT(statfile)
 
@@ -284,7 +284,7 @@ class Wea(object):
             timestep: An optional integer to set the number of time steps per
                 hour. Default is 1 for one value per hour.
             is_leap_year: A boolean to indicate if values are representing a leap year.
-                Default is False.
+                Default: False.
         """
         # extract metadata
         metadata = {'source': location.source, 'country': location.country,
@@ -340,7 +340,7 @@ class Wea(object):
             timestep: An optional integer to set the number of time steps per
                 hour. Default is 1 for one value per hour.
             is_leap_year: A boolean to indicate if values are representing a leap year.
-                Default is False.
+                Default: False.
         """
         # extract metadata
         metadata = {'source': location.source, 'country': location.country,
@@ -403,9 +403,9 @@ class Wea(object):
             timestep: An optional integer to set the number of time steps per
                 hour. Default is 1 for one value per hour.
             is_leap_year: A boolean to indicate if values are representing a leap year.
-                Default is False.
+                Default: False.
             use_disc: Set to True to use the original DISC model as opposed to the
-                newer and more accurate DIRINT model. Default is False.
+                newer and more accurate DIRINT model. Default: False.
         """
         # check input data
         assert len(cloud_cover) == len(relative_humidity) == \
@@ -652,7 +652,7 @@ class Wea(object):
                 srf_dir = dnr * math.cos(vec_angle)
 
             # diffuse irradiance on surface
-            if isotrophic is True:
+            if isotrophic:
                 srf_dif = dhr * ((math.sin(math.radians(altitude)) / 2) + 0.5)
             else:
                 y = max(0.45, 0.55 + (0.437 * math.cos(vec_angle)) + 0.313 *

--- a/tests/analysisperiod_test.py
+++ b/tests/analysisperiod_test.py
@@ -18,7 +18,7 @@ def test_default_values():
     assert ap.st_day == 1
     assert ap.end_day == 31
     assert ap.timestep == 1
-    assert ap.is_leap_year is False
+    assert not ap.is_leap_year
     assert len(ap.datetimes) == 8760
 
 

--- a/tests/datacollection_test.py
+++ b/tests/datacollection_test.py
@@ -69,7 +69,7 @@ def test_init_hourly():
     assert dc1.datetimes == (dt1, dt2)
     assert dc1.values == (v1, v2)
     assert dc1.average == avg
-    assert dc1.is_continuous is False
+    assert not dc1.is_continuous
     str(dc1)  # Test the string representation of the collection
     str(dc1.header)  # Test the string representation of the header
 
@@ -86,7 +86,7 @@ def test_init_daily():
     assert dc1.datetimes == tuple(a_per.doys_int)
     assert dc1.values == (v1, v2)
     assert dc1.average == avg
-    assert dc1.is_continuous is False
+    assert not dc1.is_continuous
     str(dc1)  # Test the string representation of the collection
     str(dc1.header)  # Test the string representation of the header
 
@@ -103,7 +103,7 @@ def test_init_monthly():
     assert dc1.datetimes == tuple(a_per.months_int)
     assert dc1.values == (v1, v2)
     assert dc1.average == avg
-    assert dc1.is_continuous is False
+    assert not dc1.is_continuous
     str(dc1)  # Test the string representation of the collection
     str(dc1.header)  # Test the string representation of the header
 
@@ -120,7 +120,7 @@ def test_init_monthly_per_hour():
     assert dc1.datetimes == tuple(a_per.months_per_hour)
     assert dc1.values == tuple(vals)
     assert dc1.average == avg
-    assert dc1.is_continuous is False
+    assert not dc1.is_continuous
     str(dc1)  # Test the string representation of the collection
     str(dc1.header)  # Test the string representation of the header
 
@@ -135,7 +135,7 @@ def test_init_continuous():
     assert len(dc1.datetimes) == 8760
     assert list(dc1.values) == list(xrange(8760))
     assert dc1.average == 4379.5
-    assert dc1.is_continuous is True
+    assert dc1.is_continuous
     str(dc1)  # Test the string representation of the collection
     str(dc1.header)  # Test the string representation of the header
 
@@ -200,8 +200,8 @@ def test_validate_a_period_hourly():
     dc1 = HourlyDiscontinuousCollection(Header(Temperature(), 'C', a_per),
                                         [v1, v2], [dt2, dt1])
     dc1_new = dc1.validate_analysis_period()
-    assert dc1.validated_a_period is False
-    assert dc1_new.validated_a_period is True
+    assert not dc1.validated_a_period
+    assert dc1_new.validated_a_period
     assert dc1.datetimes == (dt2, dt1)
     assert dc1_new.datetimes == (dt1, dt2)
 
@@ -210,8 +210,8 @@ def test_validate_a_period_hourly():
     dc1 = HourlyDiscontinuousCollection(Header(Temperature(), 'C', a_per_2),
                                         [v1, v2], [dt1, dt2])
     dc1_new = dc1.validate_analysis_period()
-    assert dc1.validated_a_period is False
-    assert dc1_new.validated_a_period is True
+    assert not dc1.validated_a_period
+    assert dc1_new.validated_a_period
     assert dc1.header.analysis_period == a_per_2
     assert dc1_new.header.analysis_period == AnalysisPeriod(
         6, 20, 12, 6, 21, 23)
@@ -240,8 +240,8 @@ def test_validate_a_period_hourly():
     dc1 = HourlyDiscontinuousCollection(Header(Temperature(), 'C', a_per),
                                         [v1, v2, v2], [dt1, dt3, dt2])
     dc1_new = dc1.validate_analysis_period()
-    assert dc1.validated_a_period is False
-    assert dc1_new.validated_a_period is True
+    assert not dc1.validated_a_period
+    assert dc1_new.validated_a_period
     assert dc1.header.analysis_period.timestep == 1
     assert dc1_new.header.analysis_period.timestep == 2
 
@@ -250,10 +250,10 @@ def test_validate_a_period_hourly():
     dc1 = HourlyDiscontinuousCollection(Header(Temperature(), 'C', a_per),
                                         [v1, v2, v2], [dt1, dt4, dt2])
     dc1_new = dc1.validate_analysis_period()
-    assert dc1.validated_a_period is False
-    assert dc1_new.validated_a_period is True
-    assert dc1.header.analysis_period.is_leap_year is False
-    assert dc1_new.header.analysis_period.is_leap_year is True
+    assert not dc1.validated_a_period
+    assert dc1_new.validated_a_period
+    assert not dc1.header.analysis_period.is_leap_year
+    assert dc1_new.header.analysis_period.is_leap_year
 
     # Test that duplicated datetimes are caught
     dc1 = HourlyDiscontinuousCollection(Header(Temperature(), 'C', a_per),
@@ -272,8 +272,8 @@ def test_validate_a_period_daily():
     dc1 = DailyCollection(Header(Temperature(), 'C', a_per),
                           [v1, v2], [dt2, dt1])
     dc1_new = dc1.validate_analysis_period()
-    assert dc1.validated_a_period is False
-    assert dc1_new.validated_a_period is True
+    assert not dc1.validated_a_period
+    assert dc1_new.validated_a_period
     assert dc1.datetimes == (dt2, dt1)
     assert dc1_new.datetimes == (dt1, dt2)
 
@@ -282,8 +282,8 @@ def test_validate_a_period_daily():
     dc1 = DailyCollection(Header(Temperature(), 'C', a_per_2),
                           [v1, v2], [dt1, dt2])
     dc1_new = dc1.validate_analysis_period()
-    assert dc1.validated_a_period is False
-    assert dc1_new.validated_a_period is True
+    assert not dc1.validated_a_period
+    assert dc1_new.validated_a_period
     assert dc1.header.analysis_period == a_per_2
     assert dc1_new.header.analysis_period == AnalysisPeriod(
         6, 20, 0, 6, 22, 23)
@@ -312,10 +312,10 @@ def test_validate_a_period_daily():
     dc1 = DailyCollection(Header(Temperature(), 'C', a_per),
                           [v1, v2, v2], [dt1, dt2, 366])
     dc1_new = dc1.validate_analysis_period()
-    assert dc1.validated_a_period is False
-    assert dc1_new.validated_a_period is True
-    assert dc1.header.analysis_period.is_leap_year is False
-    assert dc1_new.header.analysis_period.is_leap_year is True
+    assert not dc1.validated_a_period
+    assert dc1_new.validated_a_period
+    assert not dc1.header.analysis_period.is_leap_year
+    assert dc1_new.header.analysis_period.is_leap_year
 
     # Test that duplicated datetimes are caught
     dc1 = DailyCollection(Header(Temperature(), 'C', a_per),
@@ -334,8 +334,8 @@ def test_validate_a_period_monthly():
     dc1 = MonthlyCollection(Header(Temperature(), 'C', a_per),
                             [v1, v2], [dt2, dt1])
     dc1_new = dc1.validate_analysis_period()
-    assert dc1.validated_a_period is False
-    assert dc1_new.validated_a_period is True
+    assert not dc1.validated_a_period
+    assert dc1_new.validated_a_period
     assert dc1.datetimes == (dt2, dt1)
     assert dc1_new.datetimes == (dt1, dt2)
 
@@ -344,8 +344,8 @@ def test_validate_a_period_monthly():
     dc1 = MonthlyCollection(Header(Temperature(), 'C', a_per_2),
                             [v1, v2], [dt1, dt2])
     dc1_new = dc1.validate_analysis_period()
-    assert dc1.validated_a_period is False
-    assert dc1_new.validated_a_period is True
+    assert not dc1.validated_a_period
+    assert dc1_new.validated_a_period
     assert dc1.header.analysis_period == a_per_2
     assert dc1_new.header.analysis_period == AnalysisPeriod(
         6, 1, 0, 7, 31, 23)
@@ -391,8 +391,8 @@ def test_validate_a_period_monthly_per_hour():
     dc1 = MonthlyPerHourCollection(Header(Temperature(), 'C', a_per),
                                    [v1, v2], [dt2, dt1])
     dc1_new = dc1.validate_analysis_period()
-    assert dc1.validated_a_period is False
-    assert dc1_new.validated_a_period is True
+    assert not dc1.validated_a_period
+    assert dc1_new.validated_a_period
     assert dc1.datetimes == (dt2, dt1)
     assert dc1_new.datetimes == (dt1, dt2)
 
@@ -401,8 +401,8 @@ def test_validate_a_period_monthly_per_hour():
     dc1 = MonthlyPerHourCollection(Header(Temperature(), 'C', a_per_2),
                                    [v1, v2], [dt1, dt2])
     dc1_new = dc1.validate_analysis_period()
-    assert dc1.validated_a_period is False
-    assert dc1_new.validated_a_period is True
+    assert not dc1.validated_a_period
+    assert dc1_new.validated_a_period
     assert dc1.header.analysis_period == a_per_2
     assert dc1_new.header.analysis_period == AnalysisPeriod(
         6, 1, 12, 7, 31, 23)
@@ -742,7 +742,7 @@ def test_average_daily():
     assert len(new_dc) == 365
     assert new_dc.datetimes[0] == 1
     assert new_dc.datetimes[-1] == 365
-    assert new_dc.is_continuous is True
+    assert new_dc.is_continuous
     for i, val in dc.group_by_day().items():
         assert new_dc[i - 1] == sum(val) / len(val)
 
@@ -757,7 +757,7 @@ def test_total_daily():
     assert len(new_dc) == 365
     assert new_dc.datetimes[0] == 1
     assert new_dc.datetimes[-1] == 365
-    assert new_dc.is_continuous is True
+    assert new_dc.is_continuous
     for i, val in dc.group_by_day().items():
         assert new_dc[i - 1] == sum(val)
 
@@ -772,7 +772,7 @@ def test_percentile_daily():
     assert len(new_dc) == 365
     assert new_dc.datetimes[0] == 1
     assert new_dc.datetimes[-1] == 365
-    assert new_dc.is_continuous is True
+    assert new_dc.is_continuous
     for i, val in dc.group_by_day().items():
         assert new_dc[i - 1] == 5.75
 
@@ -787,7 +787,7 @@ def test_average_monthly():
     assert len(new_dc) == 12
     assert new_dc.datetimes[0] == 1
     assert new_dc.datetimes[-1] == 12
-    assert new_dc.is_continuous is True
+    assert new_dc.is_continuous
     for i, val in dc.group_by_month().items():
         assert new_dc[i - 1] == sum(val) / len(val)
 
@@ -802,7 +802,7 @@ def test_total_monthly():
     assert len(new_dc) == 12
     assert new_dc.datetimes[0] == 1
     assert new_dc.datetimes[-1] == 12
-    assert new_dc.is_continuous is True
+    assert new_dc.is_continuous
     for i, val in dc.group_by_month().items():
         assert new_dc[i - 1] == sum(val)
 
@@ -817,7 +817,7 @@ def test_percentile_monthly():
     assert len(new_dc) == 12
     assert new_dc.datetimes[0] == 1
     assert new_dc.datetimes[-1] == 12
-    assert new_dc.is_continuous is True
+    assert new_dc.is_continuous
     for i, val in dc.group_by_month().items():
         assert new_dc[i - 1] == 50
 
@@ -872,7 +872,7 @@ def test_average_monthly_per_hour():
     assert len(new_dc) == 12 * 24
     assert new_dc.datetimes[0] == (1, 0)
     assert new_dc.datetimes[-1] == (12, 23)
-    assert new_dc.is_continuous is True
+    assert new_dc.is_continuous
     for i, val in enumerate(dc.group_by_month_per_hour().values()):
         assert new_dc[i] == sum(val) / len(val)
 
@@ -887,7 +887,7 @@ def test_total_monthly_per_hour():
     assert len(new_dc) == 12 * 24
     assert new_dc.datetimes[0] == (1, 0)
     assert new_dc.datetimes[-1] == (12, 23)
-    assert new_dc.is_continuous is True
+    assert new_dc.is_continuous
     for i, val in enumerate(dc.group_by_month_per_hour().values()):
         assert new_dc[i] == sum(val)
 
@@ -902,7 +902,7 @@ def test_percentile_monthly_per_hour():
     assert len(new_dc) == 12 * 24
     assert new_dc.datetimes[0] == (1, 0)
     assert new_dc.datetimes[-1] == (12, 23)
-    assert new_dc.is_continuous is True
+    assert new_dc.is_continuous
     pct_vals = list(xrange(24)) * 12
     for i, val in enumerate(pct_vals):
         assert new_dc[i] == val
@@ -1193,7 +1193,7 @@ def test_is_in_range_data_type():
     dc2 = HourlyContinuousCollection(header1, val2)
     dc3 = HourlyContinuousCollection(header2, val3)
     dc4 = HourlyContinuousCollection(header2, val4)
-    assert dc1.is_in_data_type_range(raise_exception=False) is True
-    assert dc2.is_in_data_type_range(raise_exception=False) is False
-    assert dc3.is_in_data_type_range(raise_exception=False) is True
-    assert dc4.is_in_data_type_range(raise_exception=False) is False
+    assert dc1.is_in_data_type_range(raise_exception=False)
+    assert not dc2.is_in_data_type_range(raise_exception=False)
+    assert dc3.is_in_data_type_range(raise_exception=False)
+    assert not dc4.is_in_data_type_range(raise_exception=False)

--- a/tests/datacollectionimmutable_test.py
+++ b/tests/datacollectionimmutable_test.py
@@ -28,7 +28,7 @@ def test_hourly():
         Header(Temperature(), 'C', a_per), [v1, v2], [dt1, dt2])
     assert dc1.datetimes == (dt1, dt2)
     assert dc1.values == (v1, v2)
-    assert dc1.is_mutable is False
+    assert not dc1.is_mutable
     with pytest.raises(AttributeError):
         dc1[0] = 18
     with pytest.raises(AttributeError):
@@ -40,7 +40,7 @@ def test_hourly():
 
     dc2 = dc1.to_mutable()
     assert isinstance(dc2, HourlyDiscontinuousCollection)
-    assert dc2.is_mutable is True
+    assert dc2.is_mutable
     dc2[0] = 18
     assert dc2[0] == 18
     dc2.values = [18, 24]
@@ -50,11 +50,11 @@ def test_hourly():
 
     dc3 = dc2.to_immutable()
     assert isinstance(dc3, HourlyDiscontinuousCollectionImmutable)
-    assert dc3.is_mutable is False
+    assert not dc3.is_mutable
 
     dc4 = dc3.to_immutable()
     assert isinstance(dc4, HourlyDiscontinuousCollectionImmutable)
-    assert dc4.is_mutable is False
+    assert not dc4.is_mutable
 
 
 def test_init_continuous():
@@ -65,7 +65,7 @@ def test_init_continuous():
     dc1 = HourlyContinuousCollectionImmutable(header, values)
     assert len(dc1.datetimes) == 8760
     assert list(dc1.values) == list(xrange(8760))
-    assert dc1.is_mutable is False
+    assert not dc1.is_mutable
     with pytest.raises(AttributeError):
         dc1[0] = 18
     with pytest.raises(AttributeError):
@@ -77,7 +77,7 @@ def test_init_continuous():
 
     dc2 = dc1.to_mutable()
     assert isinstance(dc2, HourlyContinuousCollection)
-    assert dc2.is_mutable is True
+    assert dc2.is_mutable
     dc2[0] = 18
     assert dc2[0] == 18
     dc2.values = [24] * 8760
@@ -87,11 +87,11 @@ def test_init_continuous():
 
     dc3 = dc2.to_immutable()
     assert isinstance(dc3, HourlyContinuousCollectionImmutable)
-    assert dc3.is_mutable is False
+    assert not dc3.is_mutable
 
     dc4 = dc3.to_immutable()
     assert isinstance(dc4, HourlyContinuousCollectionImmutable)
-    assert dc4.is_mutable is False
+    assert not dc4.is_mutable
 
 
 def test_daily():
@@ -102,7 +102,7 @@ def test_daily():
         Header(Temperature(), 'C', a_per), [v1, v2], a_per.doys_int)
     assert dc1.datetimes == tuple(a_per.doys_int)
     assert dc1.values == (v1, v2)
-    assert dc1.is_mutable is False
+    assert not dc1.is_mutable
     with pytest.raises(AttributeError):
         dc1[0] = 18
     with pytest.raises(AttributeError):
@@ -112,7 +112,7 @@ def test_daily():
 
     dc2 = dc1.to_mutable()
     assert isinstance(dc2, DailyCollection)
-    assert dc2.is_mutable is True
+    assert dc2.is_mutable
     dc2[0] = 18
     assert dc2[0] == 18
     dc2.values = [18, 24]
@@ -122,11 +122,11 @@ def test_daily():
 
     dc3 = dc2.to_immutable()
     assert isinstance(dc3, DailyCollectionImmutable)
-    assert dc3.is_mutable is False
+    assert not dc3.is_mutable
 
     dc4 = dc3.to_immutable()
     assert isinstance(dc4, DailyCollectionImmutable)
-    assert dc4.is_mutable is False
+    assert not dc4.is_mutable
 
 
 def test_monthly():
@@ -138,7 +138,7 @@ def test_monthly():
 
     assert dc1.datetimes == tuple(a_per.months_int)
     assert dc1.values == (v1, v2)
-    assert dc1.is_mutable is False
+    assert not dc1.is_mutable
     with pytest.raises(AttributeError):
         dc1[0] = 18
     with pytest.raises(AttributeError):
@@ -148,7 +148,7 @@ def test_monthly():
 
     dc2 = dc1.to_mutable()
     assert isinstance(dc2, MonthlyCollection)
-    assert dc2.is_mutable is True
+    assert dc2.is_mutable
     dc2[0] = 18
     assert dc2[0] == 18
     dc2.values = [18, 24]
@@ -158,11 +158,11 @@ def test_monthly():
 
     dc3 = dc2.to_immutable()
     assert isinstance(dc3, MonthlyCollectionImmutable)
-    assert dc3.is_mutable is False
+    assert not dc3.is_mutable
 
     dc4 = dc3.to_immutable()
     assert isinstance(dc4, MonthlyCollectionImmutable)
-    assert dc4.is_mutable is False
+    assert not dc4.is_mutable
 
 
 def test_monthly_per_hour():
@@ -173,7 +173,7 @@ def test_monthly_per_hour():
         Header(Temperature(), 'C', a_per), vals, a_per.months_per_hour)
     assert dc1.datetimes == tuple(a_per.months_per_hour)
     assert dc1.values == tuple(vals)
-    assert dc1.is_mutable is False
+    assert not dc1.is_mutable
     with pytest.raises(AttributeError):
         dc1[0] = 18
     with pytest.raises(AttributeError):
@@ -183,7 +183,7 @@ def test_monthly_per_hour():
 
     dc2 = dc1.to_mutable()
     assert isinstance(dc2, MonthlyPerHourCollection)
-    assert dc2.is_mutable is True
+    assert dc2.is_mutable
     dc2[0] = 18
     assert dc2[0] == 18
     dc2.values = range(48)
@@ -193,11 +193,11 @@ def test_monthly_per_hour():
 
     dc3 = dc2.to_immutable()
     assert isinstance(dc3, MonthlyPerHourCollectionImmutable)
-    assert dc3.is_mutable is False
+    assert not dc3.is_mutable
 
     dc4 = dc3.to_immutable()
     assert isinstance(dc4, MonthlyPerHourCollectionImmutable)
-    assert dc4.is_mutable is False
+    assert not dc4.is_mutable
 
 
 def test_get_aligned_collection():
@@ -210,19 +210,19 @@ def test_get_aligned_collection():
     assert dc2.header.data_type.name == 'Relative Humidity'
     assert dc2.header.unit == '%'
     assert isinstance(dc2, HourlyDiscontinuousCollection)
-    assert dc2.is_mutable is True
+    assert dc2.is_mutable
 
     dc3 = dc1.get_aligned_collection(50, RelativeHumidity(), '%', mutable=False)
     assert dc3.header.data_type.name == 'Relative Humidity'
     assert dc3.header.unit == '%'
     assert isinstance(dc3, HourlyDiscontinuousCollectionImmutable)
-    assert dc3.is_mutable is False
+    assert not dc3.is_mutable
 
     dc4 = dc1.get_aligned_collection(50, RelativeHumidity(), '%', mutable=True)
     assert dc4.header.data_type.name == 'Relative Humidity'
     assert dc4.header.unit == '%'
     assert isinstance(dc4, HourlyDiscontinuousCollection)
-    assert dc4.is_mutable is True
+    assert dc4.is_mutable
 
 
 def test_get_aligned_collection_continuous():
@@ -234,16 +234,16 @@ def test_get_aligned_collection_continuous():
     assert dc2.header.data_type.name == 'Relative Humidity'
     assert dc2.header.unit == '%'
     assert isinstance(dc2, HourlyContinuousCollection)
-    assert dc2.is_mutable is True
+    assert dc2.is_mutable
 
     dc3 = dc1.get_aligned_collection(50, RelativeHumidity(), '%', mutable=False)
     assert dc3.header.data_type.name == 'Relative Humidity'
     assert dc3.header.unit == '%'
     assert isinstance(dc3, HourlyContinuousCollectionImmutable)
-    assert dc3.is_mutable is False
+    assert not dc3.is_mutable
 
     dc4 = dc1.get_aligned_collection(50, RelativeHumidity(), '%', mutable=True)
     assert dc4.header.data_type.name == 'Relative Humidity'
     assert dc4.header.unit == '%'
     assert isinstance(dc4, HourlyContinuousCollection)
-    assert dc4.is_mutable is True
+    assert dc4.is_mutable

--- a/tests/epw_test.py
+++ b/tests/epw_test.py
@@ -20,10 +20,10 @@ def test_import_epw():
     assert epw.file_path == abs_path
     assert epw.location.city == 'Chicago Ohare Intl Ap'
     # Check that calling location getter only retrieves location
-    assert epw.is_data_loaded is False
+    assert not epw.is_data_loaded
     dbt = epw.dry_bulb_temperature
     skyt = epw.sky_temperature  # test sky temperature calculation
-    assert epw.is_data_loaded is True
+    assert epw.is_data_loaded
     assert len(dbt) == 8760
     assert len(skyt) == 8760
 
@@ -32,20 +32,20 @@ def test_import_tokyo_epw():
     """Test import standard epw from another location."""
     path = './tests/fixtures/epw/tokyo.epw'
     epw = EPW(path)
-    assert epw.is_header_loaded is False
+    assert not epw.is_header_loaded
     assert epw.location.city == 'Tokyo'
-    assert epw.is_header_loaded is True
-    assert epw.is_data_loaded is False
+    assert epw.is_header_loaded
+    assert not epw.is_data_loaded
     dbt = epw.dry_bulb_temperature
-    assert epw.is_data_loaded is True
+    assert epw.is_data_loaded
     assert len(dbt) == 8760
 
 
 def test_epw_from_missing_values():
     """Test import custom epw with wrong types."""
     epw = EPW.from_missing_values()
-    assert epw.is_header_loaded is True
-    assert epw.is_data_loaded is True
+    assert epw.is_header_loaded
+    assert epw.is_data_loaded
     assert len(epw.dry_bulb_temperature) == 8760
     assert list(epw.dry_bulb_temperature.values) == [99.9] * 8760
 

--- a/tests/graphic_test.py
+++ b/tests/graphic_test.py
@@ -33,10 +33,10 @@ def test_init_graphic_con():
     assert isinstance(graphic_con.legend, Legend)
     assert graphic_con.value_colors == graphic_con.legend.value_colors
 
-    assert graphic_con.legend_parameters.is_base_plane_default is False
-    assert graphic_con.legend_parameters.is_segment_height_default is False
-    assert graphic_con.legend_parameters.is_segment_width_default is True
-    assert graphic_con.legend_parameters.is_text_height_default is True
+    assert not graphic_con.legend_parameters.is_base_plane_default
+    assert not graphic_con.legend_parameters.is_segment_height_default
+    assert graphic_con.legend_parameters.is_segment_width_default
+    assert graphic_con.legend_parameters.is_text_height_default
     assert graphic_con.legend_parameters.base_plane != Plane()
 
     assert isinstance(graphic_con.lower_title_location, Plane)
@@ -97,11 +97,11 @@ def test_init_graphic_con_legend_parameters():
     legend_par.text_height = 0.15
     graphic_con = GraphicContainer(data, mesh3d.min, mesh3d.max, legend_par)
 
-    assert graphic_con.legend_parameters.is_base_plane_default is False
-    assert graphic_con.legend_parameters.is_segment_height_default is False
-    assert graphic_con.legend_parameters.is_segment_width_default is False
-    assert graphic_con.legend_parameters.is_text_height_default is False
-    assert graphic_con.legend_parameters.vertical is False
+    assert not graphic_con.legend_parameters.is_base_plane_default
+    assert not graphic_con.legend_parameters.is_segment_height_default
+    assert not graphic_con.legend_parameters.is_segment_width_default
+    assert not graphic_con.legend_parameters.is_text_height_default
+    assert not graphic_con.legend_parameters.vertical
     assert graphic_con.legend_parameters.base_plane.o == Point3D(2, 2, 0)
     assert graphic_con.legend_parameters.segment_height == 0.25
     assert graphic_con.legend_parameters.segment_width == 0.5
@@ -116,7 +116,7 @@ def test_init_graphic_con_data_type():
     graphic_con = GraphicContainer(data, mesh3d.min, mesh3d.max,
                                    data_type=Temperature())
 
-    assert graphic_con.legend_parameters.is_title_default is False
+    assert not graphic_con.legend_parameters.is_title_default
     assert graphic_con.legend_parameters.title == 'C'
 
     legend_par = LegendParameters()
@@ -124,7 +124,7 @@ def test_init_graphic_con_data_type():
     graphic_con = GraphicContainer(data, mesh3d.min, mesh3d.max,
                                    legend_par, data_type=Temperature())
 
-    assert graphic_con.legend_parameters.is_title_default is False
+    assert not graphic_con.legend_parameters.is_title_default
     assert graphic_con.legend_parameters.title == 'Temperature (C)'
 
 
@@ -139,7 +139,7 @@ def test_init_graphic_con_data_type_ordinal():
     assert graphic_con.legend_parameters.min == -3
     assert graphic_con.legend_parameters.max == 3
     assert graphic_con.legend_parameters.segment_count == 7
-    assert graphic_con.legend_parameters.is_title_default is False
+    assert not graphic_con.legend_parameters.is_title_default
     assert graphic_con.legend_parameters.title == 'PMV'
     assert graphic_con.legend.segment_text == ['Cold', 'Cool', 'Slightly Cool',
                                                'Neutral',

--- a/tests/legend_test.py
+++ b/tests/legend_test.py
@@ -21,12 +21,12 @@ def test_init_legend_parameters():
 
     assert leg_par.min == 0
     assert leg_par.max == 1000
-    assert leg_par.is_segment_count_default is True
-    assert leg_par.is_title_default is True
-    assert leg_par.is_base_plane_default is True
-    assert leg_par.is_segment_height_default is True
-    assert leg_par.is_segment_width_default is True
-    assert leg_par.is_text_height_default is True
+    assert leg_par.is_segment_count_default
+    assert leg_par.is_title_default
+    assert leg_par.is_base_plane_default
+    assert leg_par.is_segment_height_default
+    assert leg_par.is_segment_width_default
+    assert leg_par.is_text_height_default
 
     leg_par_copy = leg_par.duplicate()
     assert leg_par_copy.min == leg_par.min
@@ -69,12 +69,12 @@ def test_continuous_colors():
     leg_par = LegendParameters()
     leg_par.continuous_colors = False
 
-    assert leg_par.continuous_colors is False
+    assert not leg_par.continuous_colors
     leg_par_copy = leg_par.duplicate()
-    assert leg_par_copy.continuous_colors is False
+    assert not leg_par_copy.continuous_colors
 
     leg_par.continuous_colors = True
-    assert leg_par.continuous_colors is True
+    assert leg_par.continuous_colors
 
     with pytest.raises(Exception):
         leg_par = LegendParameters(continuous_colors='yes')
@@ -87,12 +87,12 @@ def test_continuous_legend():
     leg_par = LegendParameters()
     leg_par.continuous_legend = True
 
-    assert leg_par.continuous_legend is True
+    assert leg_par.continuous_legend
     leg_par_copy = leg_par.duplicate()
-    assert leg_par_copy.continuous_legend is True
+    assert leg_par_copy.continuous_legend
 
     leg_par.continuous_legend = False
-    assert leg_par.continuous_legend is False
+    assert not leg_par.continuous_legend
 
     with pytest.raises(Exception):
         leg_par = LegendParameters(continuous_legend='yes')
@@ -105,7 +105,7 @@ def test_title():
     leg_par = LegendParameters(title='m2')
 
     assert leg_par.title == 'm2'
-    assert leg_par.is_title_default is False
+    assert not leg_par.is_title_default
     leg_par_copy = leg_par.duplicate()
     assert leg_par_copy.title == 'm2'
 
@@ -159,12 +159,12 @@ def test_vertical():
     leg_par = LegendParameters()
     leg_par.vertical = False
 
-    assert leg_par.vertical is False
+    assert not leg_par.vertical
     leg_par_copy = leg_par.duplicate()
-    assert leg_par_copy.vertical is False
+    assert not leg_par_copy.vertical
 
     leg_par.vertical = True
-    assert leg_par.vertical is True
+    assert leg_par.vertical
 
     with pytest.raises(Exception):
         leg_par = LegendParameters(vertical='yes')
@@ -178,7 +178,7 @@ def test_base_plane():
         base_plane=Plane(Vector3D(0, 0, 0), Point3D(10, 10, 0)))
 
     assert leg_par.base_plane.o == Point3D(10, 10, 0)
-    assert leg_par.is_base_plane_default is False
+    assert not leg_par.is_base_plane_default
     leg_par_copy = leg_par.duplicate()
     assert leg_par_copy.base_plane.o == Point3D(10, 10, 0)
 
@@ -197,7 +197,7 @@ def test_segment_height():
     leg_par.segment_height = 3
 
     assert leg_par.segment_height == 3
-    assert leg_par.is_segment_height_default is False
+    assert not leg_par.is_segment_height_default
     leg_par_copy = leg_par.duplicate()
     assert leg_par_copy.segment_height == 3
 
@@ -216,7 +216,7 @@ def test_segment_width():
     leg_par.segment_width = 3
 
     assert leg_par.segment_width == 3
-    assert leg_par.is_segment_width_default is False
+    assert not leg_par.is_segment_width_default
     leg_par_copy = leg_par.duplicate()
     assert leg_par_copy.segment_width == 3
 
@@ -235,7 +235,7 @@ def test_text_height():
     leg_par.text_height = 0.25
 
     assert leg_par.text_height == 0.25
-    assert leg_par.is_text_height_default is False
+    assert not leg_par.is_text_height_default
     leg_par_copy = leg_par.duplicate()
     assert leg_par_copy.text_height == 0.25
 
@@ -280,14 +280,14 @@ def test_init_legend():
     assert len(legend.values) == 2
     assert legend.legend_parameters.min == 0
     assert legend.legend_parameters.max == 10
-    assert legend.is_min_default is True
-    assert legend.is_max_default is True
-    assert legend.legend_parameters.is_segment_count_default is True
-    assert legend.legend_parameters.is_title_default is True
-    assert legend.legend_parameters.is_base_plane_default is True
-    assert legend.legend_parameters.is_segment_height_default is True
-    assert legend.legend_parameters.is_segment_width_default is True
-    assert legend.legend_parameters.is_text_height_default is True
+    assert legend.is_min_default
+    assert legend.is_max_default
+    assert legend.legend_parameters.is_segment_count_default
+    assert legend.legend_parameters.is_title_default
+    assert legend.legend_parameters.is_base_plane_default
+    assert legend.legend_parameters.is_segment_height_default
+    assert legend.legend_parameters.is_segment_width_default
+    assert legend.legend_parameters.is_text_height_default
 
     legend_copy = legend.duplicate()
     assert legend_copy.values == legend.values
@@ -295,14 +295,14 @@ def test_init_legend():
     assert legend_copy.legend_parameters.max == legend.legend_parameters.max
     assert legend_copy.legend_parameters.segment_count == \
         legend.legend_parameters.segment_count
-    assert legend_copy.is_min_default is True
-    assert legend_copy.is_max_default is True
-    assert legend_copy.legend_parameters.is_segment_count_default is True
-    assert legend_copy.legend_parameters.is_title_default is True
-    assert legend_copy.legend_parameters.is_base_plane_default is True
-    assert legend_copy.legend_parameters.is_segment_height_default is True
-    assert legend_copy.legend_parameters.is_segment_width_default is True
-    assert legend_copy.legend_parameters.is_text_height_default is True
+    assert legend_copy.is_min_default
+    assert legend_copy.is_max_default
+    assert legend_copy.legend_parameters.is_segment_count_default
+    assert legend_copy.legend_parameters.is_title_default
+    assert legend_copy.legend_parameters.is_base_plane_default
+    assert legend_copy.legend_parameters.is_segment_height_default
+    assert legend_copy.legend_parameters.is_segment_width_default
+    assert legend_copy.legend_parameters.is_text_height_default
 
 
 def test_init_legend_with_parameter():
@@ -312,8 +312,8 @@ def test_init_legend_with_parameter():
     assert len(legend.values) == 2
     assert legend.legend_parameters.min == 2
     assert legend.legend_parameters.max == 8
-    assert legend.is_min_default is False
-    assert legend.is_max_default is False
+    assert not legend.is_min_default
+    assert not legend.is_max_default
 
 
 def test_legend_to_from_dict():
@@ -342,13 +342,13 @@ def test_legend_title():
     """Test the title property."""
     legend = Legend(range(5))
     assert legend.title == ''
-    assert legend.legend_parameters.is_title_default is True
+    assert legend.legend_parameters.is_title_default
     assert legend.title_location.o == Point3D(0, 11.25, 0)
     assert legend.title_location_2d == Point2D(0, 11.25)
 
     legend = Legend(range(5), LegendParameters(segment_count=5, title='C'))
     assert legend.title == 'C'
-    assert legend.legend_parameters.is_title_default is False
+    assert not legend.legend_parameters.is_title_default
     assert legend.title_location.o == Point3D(0, 5.25, 0)
     assert legend.title_location_2d == Point2D(0, 5.25)
 

--- a/tests/sunpath_test.py
+++ b/tests/sunpath_test.py
@@ -47,8 +47,8 @@ def test_daylight_saving():
     sp = Sunpath.from_location(nyc, daylight_saving_period=daylight_saving)
     dt1 = DateTime(6, 21, 12, 0)
     dt2 = DateTime(12, 21, 12, 0)
-    assert sp.is_daylight_saving_hour(dt1) is True
-    assert sp.is_daylight_saving_hour(dt2) is False
+    assert sp.is_daylight_saving_hour(dt1)
+    assert not sp.is_daylight_saving_hour(dt2)
 
 
 def test_leap_year():


### PR DESCRIPTION
The PEP8 police should appreciate this commit. It's purely a style commit that removes all situations of `is True` and `is False` from the library, replacing them with the correct PEP8 version.