### PR TITLE
fix(designday): Use Date object for DesignDay

### DIFF
--- a/ladybug/analysisperiod.py
+++ b/ladybug/analysisperiod.py
@@ -243,7 +243,7 @@ class AnalysisPeriod(object):
 
     @property
     def datetimes(self):
-        """A sorted list of datetimes in this analysis period."""
+        """A sorted list of hourly datetimes in this analysis period."""
         if self._timestamps_data is None:
             self._calculate_timestamps()
         return tuple(DateTime.from_moy(moy, self.is_leap_year)
@@ -251,7 +251,8 @@ class AnalysisPeriod(object):
 
     @property
     def moys(self):
-        """A sorted list of minutes of year in this analysis period as integers."""
+        """A sorted list of hourly minutes of year in this analysis period as integers.
+        """
         if self._timestamps_data is None:
             self._calculate_timestamps()
         return self._timestamps_data

--- a/ladybug/stat.py
+++ b/ladybug/stat.py
@@ -2,6 +2,7 @@
 from __future__ import division
 
 from .location import Location
+from .dt import Date
 from .analysisperiod import AnalysisPeriod
 from .designday import DesignDay
 from .designday import DryBulbCondition
@@ -640,8 +641,8 @@ class STAT(object):
     def monthly_clear_sky_conditions(self):
         """A list of 12 monthly clear sky conditions that are used on the design days."""
         if self._monthly_tau_diffuse is [] or self._monthly_tau_beam is []:
-            return [ASHRAEClearSky(i, 21) for i in xrange(1, 13)]
-        return [ASHRAETau(i, 21, x, y) for i, x, y in zip(
+            return [ASHRAEClearSky(Date(i, 21)) for i in xrange(1, 13)]
+        return [ASHRAETau(Date(i, 21), x, y) for i, x, y in zip(
             list(xrange(1, 13)), self._monthly_tau_beam, self._monthly_tau_diffuse)]
 
     @property

--- a/tests/ddy_test.py
+++ b/tests/ddy_test.py
@@ -2,6 +2,7 @@
 from pytest import approx
 import os
 from ladybug.location import Location
+from ladybug.dt import Date
 from ladybug.analysisperiod import AnalysisPeriod
 from ladybug.designday import DesignDay
 from ladybug.ddy import DDY
@@ -119,10 +120,10 @@ def test_design_day_from_properties():
     """Test hourly data properties of a standard ddy."""
     location = Location('Test City', '-', 'USA', 34.20, -118.35, -8, 226)
     a_period = AnalysisPeriod(12, 21, 0, 12, 21, 23)
-    des_day = DesignDay.from_design_day_properties('Test Day', 'WinterDesignDay',
-                                                   location, a_period, 3.9, 0,
-                                                   'Wetbulb', 3.9, 98639, 0.8, 330,
-                                                   'ASHRAEClearSky', [0])
+    date = Date(12, 21)
+    des_day = DesignDay.from_design_day_properties(
+        'Test Day', 'WinterDesignDay', location, date, 3.9, 0,
+        'Wetbulb', 3.9, 98639, 0.8, 330, 'ASHRAEClearSky', [0])
     assert des_day.location == location
     new_period = des_day.analysis_period
     assert new_period.st_month == a_period.st_month
@@ -136,11 +137,10 @@ def test_design_day_from_properties():
 def test_design_day_hourly_data():
     """Test hourly data properties of a standard ddy."""
     location = Location('Test City', '-', 'USA', 34.20, -118.35, -8, 226)
-    a_period = AnalysisPeriod(8, 21, 0, 8, 21, 23)
-    des_day = DesignDay.from_design_day_properties('Test Day', 'SummerDesignDay',
-                                                   location, a_period, 36.8, 13.2,
-                                                   'Wetbulb', 20.5, 98639, 3.9, 170,
-                                                   'ASHRAETau', [0.436, 2.106])
+    date = Date(8, 21)
+    des_day = DesignDay.from_design_day_properties(
+        'Test Day', 'SummerDesignDay', location, date, 36.8, 13.2,
+        'Wetbulb', 20.5, 98639, 3.9, 170, 'ASHRAETau', [0.436, 2.106])
     # dry bulb values
     db_data_collect = des_day.hourly_dry_bulb
     assert db_data_collect[5] == approx(23.6, rel=1e-1)

--- a/tests/stat_test.py
+++ b/tests/stat_test.py
@@ -59,7 +59,7 @@ def test_annual_heating_design_days():
     assert ann_hdd_96.name == '99.6% Heating Design Day for Chicago Ohare Intl Ap'
     assert ann_hdd_96.analysis_period.st_month == \
         ann_hdd_96.analysis_period.end_month == \
-        ann_hdd_96.sky_condition.month == 1
+        ann_hdd_96.sky_condition.date.month == 1
     assert ann_hdd_96.analysis_period.st_day == \
         ann_hdd_96.analysis_period.end_day == 21
     assert ann_hdd_96.humidity_condition.humidity_type == 'Wetbulb'
@@ -87,7 +87,7 @@ def test_annual_cooling_design_days():
     assert ann_cdd_04.name == '0.4% Cooling Design Day for TOKYO HYAKURI'
     assert ann_cdd_04.analysis_period.st_month == \
         ann_cdd_04.analysis_period.end_month == \
-        ann_cdd_04.sky_condition.month == 8
+        ann_cdd_04.sky_condition.date.month == 8
     assert ann_cdd_04.analysis_period.st_day == \
         ann_cdd_04.analysis_period.end_day == 21
     assert ann_cdd_04.humidity_condition.humidity_type == 'Wetbulb'


### PR DESCRIPTION
I realized that the only reason why I was requesting separate inputs for month and day_of_month was because I originally wrote this class before we had Date objects in the dt module. So this commit is replacing these two inputs with a Date object and this should be less prone to errors (like invalid dates).