### PR TITLE
ci(dependabot): Add config file for Dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,13 @@
+version: 1
+update_configs:
+  - package_manager: "python"
+    directory: "/"
+    update_schedule: "live"
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "all"
+    commit_message:
+      prefix: "fix"
+      prefix_development: "chore"
+      include_scope: true


### PR DESCRIPTION
Adding this config file means that, whenever there is a new release of ladybug-geometry on PyPI, dependabot will immediately send a PR to this repo to ensure that there is a release of ladybug-core that is compatible with this version of ladybug-geometry.

Given that we have auto-merging turned on for this repo, this PR should be automatically merged if the tests pass, meaning there will automatically be a new release of ladybug-core whenever we release ladybug-geometry. 

I will implement a similar config file on all of the other parts of the core dependency tree (ladybug-comfort, honeybee-core, honeybee extensions, dragonfly-core, dragonfly extensions). So an update anywhere along the dependency tree will automatically "trickle up" towards the branches above it unless the tests fail somewhere along this path. If the tests fail, we can step in and manually fix it. Then the rest of the "trickle up" process continues once our fix is merged.

I realize that this system will result in many more releases of core libraries. But this seems to be the price we pay for using == operators for our dependencies in requirements.txt as opposed to >= operators. Given the strictness of the == right now, we almost never end up with a compatible set of core libraries on PyPI. This system will correct this without us resorting back to >= operators.

@mostaphaRoudsari , I'll request your review on the other PRs I send but let's use this PR here if you have any feedback about this system.