### PR TITLE
fix(datatype): remove slots

### DIFF
--- a/ladybug/datatype/base.py
+++ b/ladybug/datatype/base.py
@@ -26,7 +26,6 @@ class DataTypeBase(object):
         *   cumulative
         *   normalized_type
     """
-    __slots__ = ('_name',)
     _units = [None]
     _si_units = [None]
     _ip_units = [None]


### PR DESCRIPTION
Slots don't seem to provide a major memory advantage at this point as they are not implemented on
child classes. There is a preference to remove them so certain functions can be overwritten by
plugins.

close #256