### PR TITLE
feat(pypi): Change PyPI package name to ladybug-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,14 @@ Ladybug is a Python library to load, analyze and modify EnergyPlus Weather files
 This repository includes the core library which is the base for Ladybug. For plugin-specific questions and comments refer to [ladybug-grasshopper](https://github.com/ladybug-tools/ladybug-grasshopper) or [ladybug-dynamo](https://github.com/ladybug-tools/ladybug-dynamo) repositories.
 
 ## Note
+
 For the Legacy Ladybug Grasshopper Plugin see [this repository](https://github.com/ladybug-tools/ladybug-legacy).
 
 ## [API Documentation](https://www.ladybug.tools/ladybug/docs/ladybug.html)
 
 ## Installation
 
-`pip install lbt-ladybug`
+`pip install ladybug-core`
 
 
 ## Usage
@@ -46,12 +47,11 @@ print('altitude: {}, azimuth: {}'.format(sun.altitude, sun.azimuth))
 >>> altitude: 72.26, azimuth: 32.37
 ```
 
-
 ### Derivative Work
+
 Ladybug is a derivative work of the following software projects:
 
-[ladybug-geometry](https://github.com/ladybug-tools/ladybug-geometry) for vector math calculation. Available under GNU GPL.
-
 [PVLib-python](https://github.com/pvlib/pvlib-python) for solar irradiance calculations. Available under BSD 3-clause.
+[PsychroLib](https://github.com/psychrometrics/psychrolib) for psychrometric calculations. Available under MIT License.
 
 Applicable copyright notices for these works can be found within the relevant .py files.

--- a/ladybug/config.py
+++ b/ladybug/config.py
@@ -41,7 +41,7 @@ class Folders(object):
     def ladybug_tools_folder(self):
         """Get or set the path to the ladybug tools installation folder."""
         return self._ladybug_tools_folder
-    
+
     @ladybug_tools_folder.setter
     def ladybug_tools_folder(self, path):
         if not path:  # check the default location for epw files
@@ -119,7 +119,7 @@ class Folders(object):
 
     def _find_default_epw_folder(self):
         """Find the the default EPW folder in its usual location.
-        
+
         An attempt will be made to create the directory if it does not already exist.
         """
         epw_folder = os.path.join(self.ladybug_tools_folder, 'resources', 'weather')
@@ -134,7 +134,7 @@ class Folders(object):
     @staticmethod
     def _find_default_ladybug_tools_folder():
         """Find the the default ladybug_tools folder in its usual location.
-        
+
         An attempt will be made to create the directory if it does not already exist.
         """
         home_folder = os.getenv('HOME') or os.path.expanduser('~')

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,12 @@ with open('requirements.txt') as f:
     requirements = f.read().splitlines()
 
 setuptools.setup(
-    name="lbt-ladybug",
+    name="ladybug-core",
     use_scm_version=True,
     setup_requires=['setuptools_scm'],
     author="Ladybug Tools",
     author_email="info@ladybug.tools",
-    description="Ladybug is a Python library to load, analyze and modify EneregyPlus Weather files (epw).",
+    description="Python library to load, analyze and modify EnergyPlus Weather files (epw).",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/ladybug-tools/ladybug",


### PR DESCRIPTION
Since lbt-ladybug will be used as a shortcut to install ladybug with all of its extensions (eg. ladybug-comfort).

There's nothing to review here, @mostaphaRoudsari . I just wanted you to be aware that this change is underway.