### PR TITLE
perf(analysisperiod) Improve performance of AnalysisPeriod datetimes

### DIFF
--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -604,7 +604,7 @@ class HourlyContinuousCollection(HourlyDiscontinuousCollection):
     def datetimes(self):
         """Return datetimes for this collection as a tuple."""
         if self._datetimes is None:
-            self._datetimes = tuple(self.header.analysis_period.datetimes)
+            self._datetimes = self.header.analysis_period.datetimes
         return self._datetimes
 
     def interpolate_holes(self):
@@ -956,15 +956,9 @@ class HourlyContinuousCollection(HourlyDiscontinuousCollection):
         assert isinstance(values, Iterable) and not isinstance(
             values, (str, dict, bytes, bytearray)), \
             'values should be a list or tuple. Got {}'.format(type(values))
-        if self.header.analysis_period.is_annual:
-            a_period_len = 8760 * self.header.analysis_period.timestep
-            if self.header.analysis_period.is_leap_year:
-                a_period_len = a_period_len + 24 * self.header.analysis_period.timestep
-        else:
-            a_period_len = len(self.header.analysis_period.moys)
-        assert len(values) == a_period_len, \
-            'Length of values does not match that expected by the '\
-            'header analysis_period. {} != {}'.format(len(values), a_period_len)
+        assert len(values) == len(self.header.analysis_period), 'Length of ' \
+            'values does not match that expected by the header analysis_period.'\
+            ' {} != {}'.format(len(values), len(self.header.analysis_period))
 
     @property
     def is_continuous(self):

--- a/ladybug/dt.py
+++ b/ladybug/dt.py
@@ -172,6 +172,26 @@ class DateTime(datetime):
         leap_year = True if date.year % 4 == 0 else False
         return cls(date.month, date.day, time.hour, time.minute, leap_year)
 
+    @classmethod
+    def from_first_hour(cls, leap_year=False):
+        """Create Ladybug DateTime for the first hour of the year.
+
+        Args:
+            leap_year: Boolean to note whether the Date Time is a part of a
+                leap year. Default: False.
+        """
+        return cls(1, 1, 0, leap_year=leap_year)
+
+    @classmethod
+    def from_last_hour(cls, leap_year=False):
+        """Create Ladybug DateTime for the last hour of the year.
+
+        Args:
+            leap_year: Boolean to note whether the Date Time is a part of a
+                leap year. Default: False.
+        """
+        return cls(12, 31, 23, leap_year=leap_year)
+
     @property
     def leap_year(self):
         """Boolean to note whether DateTime belongs to a leap year or not."""

--- a/tests/analysisperiod_test.py
+++ b/tests/analysisperiod_test.py
@@ -23,7 +23,7 @@ def test_default_values():
 
 
 def test_from_string():
-    """Test creating analysis priod from a string."""
+    """Test creating analysis period from a string."""
     ap_string = '2/21 to 3/22 between 5 to 17 @1'
     ap = AnalysisPeriod.from_analysis_period(ap_string)
     ap = AnalysisPeriod.from_string(ap_string)
@@ -64,6 +64,7 @@ def test_include_last_hour():
     assert last_hour.hour == 15
     assert last_hour.minute == 0
     assert len(ap) == 25
+    assert len(ap.datetimes) == 25
 
 
 def test_default_values_leap_year():


### PR DESCRIPTION
This commit includes a number of performance improvements to the analysis period and (by extension) the hourly continuous data collection.  The biggest improvement comes from the fact that we can get the length of the analysis period without having to create all of the individual datetime objects (we just look at the time difference between the start and end datetimes). Also, when a case arrives that datetimes are needed, these datetimes get cached on the AnalysisPeriod object instead of regenerating them every time that they are called. This should dramatically cut down on the number of datetime objects that we are storing in memory at a given time.

The improvement is good enough that I can even notice the tests running faster.

Technically, there's also a bug fix in this commit but it affects such a niche edge case (reversed analysis periods for leap years) that I don't think it's worth a whole new release right now.