### PR TITLE
feat(epw): Add method to derive DDY from EPW

### DIFF
--- a/ladybug/_datacollectionbase.py
+++ b/ladybug/_datacollectionbase.py
@@ -186,7 +186,7 @@ class BaseCollection(object):
         new_obj._validated_a_period = self._validated_a_period
         return new_obj
 
-    def get_highest_values(self, count):
+    def highest_values(self, count):
         """Get a list of the the x highest values of the Data Collection and their indices.
 
         This is useful for situations where one needs to know the times of
@@ -221,7 +221,7 @@ class BaseCollection(object):
                                       reverse=True)[0:count]
         return highest_values, highest_values_index
 
-    def get_lowest_values(self, count):
+    def lowest_values(self, count):
         """Get a list of the the x lowest values of the Data Collection and their indices.
 
         This is useful for situations where one needs to know the times of
@@ -251,7 +251,7 @@ class BaseCollection(object):
                                      key=lambda k: self._values[k])[0:count]
         return lowest_values, lowest_values_index
 
-    def get_percentile(self, percentile):
+    def percentile(self, percentile):
         """Get a value representing a the input percentile of the Data Collection.
 
         Args:

--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -16,7 +16,7 @@ Collections have the following inheritance structure:
 
 
 All Data Collections in this module have the ability to:
-    * max, min, bounds, average, median, total, get_percentile, get_highest/lowest values
+    * max, min, bounds, average, median, total, percentile, highest/lowest values
     * perform unit conversions on the data: to_unit, to_ip, to_si
     * filter based on conditional statements
     * filter based on analysis period

--- a/tests/datacollection_test.py
+++ b/tests/datacollection_test.py
@@ -596,48 +596,48 @@ def test_to_ip_si():
     assert dc3.values[0] == dc1.values[0]
 
 
-def test_get_highest_values():
+def test_highest_values():
     header = Header(Temperature(), 'C', AnalysisPeriod())
     test_data = list(xrange(8760))
     test_count = len(test_data)/2
     dc3 = HourlyContinuousCollection(header, test_data)
 
     test_highest_values, test_highest_values_index = \
-        dc3.get_highest_values(test_count)
+        dc3.highest_values(test_count)
 
     assert test_highest_values == list(reversed(test_data[4380:8760]))
     assert test_highest_values_index == list(xrange(8759, 4379, -1))
 
 
-def test_get_lowest_values():
+def test_lowest_values():
     header = Header(Temperature(), 'C', AnalysisPeriod())
     test_data = [50] * 8760
     test_count = len(test_data)/2
     dc3 = HourlyContinuousCollection(header, test_data)
 
     test_lowest_values, test_lowest_values_index = \
-        dc3.get_lowest_values(test_count)
+        dc3.lowest_values(test_count)
 
     assert test_lowest_values == list(test_data[0:4380])
     assert test_lowest_values_index == list(xrange(0, 4380))
 
 
-def test_get_percentile():
-    """Test the get_percentile method."""
+def test_percentile():
+    """Test the percentile method."""
     header1 = Header(Temperature(), 'C', AnalysisPeriod())
     values = list(xrange(8760))
     dc = HourlyContinuousCollection(header1, values)
 
-    assert dc.get_percentile(0) == 0
-    assert dc.get_percentile(25) == 2189.75
-    assert dc.get_percentile(50) == 4379.5
-    assert dc.get_percentile(75) == 6569.25
-    assert dc.get_percentile(100) == 8759
+    assert dc.percentile(0) == 0
+    assert dc.percentile(25) == 2189.75
+    assert dc.percentile(50) == 4379.5
+    assert dc.percentile(75) == 6569.25
+    assert dc.percentile(100) == 8759
 
     with pytest.raises(Exception):
-        dc.get_percentile(-10)
+        dc.percentile(-10)
     with pytest.raises(Exception):
-        dc.get_percentile(110)
+        dc.percentile(110)
 
 
 def test_filter_by_conditional_statement():

--- a/tests/epw_test.py
+++ b/tests/epw_test.py
@@ -334,6 +334,24 @@ def test_save_converted_epw():
     os.remove(modified_path)
 
 
+def test_save_ddy():
+    """Test save wea_rel."""
+    path = './tests/fixtures/epw/chicago.epw'
+    epw = EPW(path)
+
+    ddy_path = './tests/fixtures/epw/chicago_epw.ddy'
+    epw.to_ddy(ddy_path)
+    assert os.path.isfile(ddy_path)
+    assert os.stat(ddy_path).st_size > 1
+    os.remove(ddy_path)
+
+    ddy_path = './tests/fixtures/epw/chicago_epw_02.ddy'
+    epw.to_ddy(ddy_path, 2)
+    assert os.path.isfile(ddy_path)
+    assert os.stat(ddy_path).st_size > 1
+    os.remove(ddy_path)
+
+
 def test_save_wea():
     """Test save wea_rel."""
     path = './tests/fixtures/epw/chicago.epw'


### PR DESCRIPTION
This commit adds a method to the EPW class that can derive a DDY from the EPW file. The DDYs produced by this method are not as representative of the climate as the ones distributed with the EPWs but this will help a lot when running energy simulations with EPW files that have no design associated with them.

I also changed the name of a few methods that start with `get_` that aren't being used by anything that I know if right now. It's better to change this now before we start doing more with these methods.

Resolves https://github.com/ladybug-tools/ladybug/issues/308