### PR TITLE
fix(datacollection): Add method to normalize data by area

### DIFF
--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -839,8 +839,7 @@ class HourlyContinuousCollection(HourlyDiscontinuousCollection):
 
     def duplicate(self):
         """Return a copy of the current Data Collection."""
-        return self.__class__(
-            self.header.duplicate(), self._values)
+        return self.__class__(self.header.duplicate(), list(self._values))
 
     def get_aligned_collection(self, value=0, data_type=None, unit=None, mutable=None):
         """Return a Collection aligned with this one composed of one repeated value.

--- a/ladybug/datacollectionimmutable.py
+++ b/ladybug/datacollectionimmutable.py
@@ -48,6 +48,13 @@ class _ImmutableCollectionBase(object):
         """Get an immutable version of this collection."""
         return self.duplicate()
 
+    def duplicate(self):
+        """Get a copy of this Data Collection."""
+        collection = self.__class__(
+            self.header.duplicate(), self._values, self.datetimes)
+        collection._validated_a_period = self._validated_a_period
+        return collection
+
     def __setitem__(self, key, value):
         raise AttributeError(self._mutable_message)
 
@@ -80,6 +87,10 @@ class HourlyContinuousCollectionImmutable(
         new_obj = HourlyContinuousCollection(self.header, self.values)
         new_obj._validated_a_period = self._validated_a_period
         return new_obj
+
+    def duplicate(self):
+        """Return a copy of the current Data Collection."""
+        return self.__class__(self.header.duplicate(), self._values)
 
 
 class DailyCollectionImmutable(

--- a/ladybug/datatype/time.py
+++ b/ladybug/datatype/time.py
@@ -33,7 +33,7 @@ class Time(DataTypeBase):
 
     def to_unit(self, values, unit, from_unit):
         """Return values converted to the unit given the input from_unit."""
-        return self._to_unit_base('fraction', values, unit, from_unit)
+        return self._to_unit_base('hr', values, unit, from_unit)
 
     def to_ip(self, values, from_unit):
         """Return values in IP and the units to which the values have been converted."""

--- a/ladybug/header.py
+++ b/ladybug/header.py
@@ -46,7 +46,7 @@ class Header(object):
         self._data_type = data_type
         self._unit = unit
         self._analysis_period = analysis_period
-        self._metadata = metadata or {}
+        self.metadata = metadata
 
     @classmethod
     def from_dict(cls, data):
@@ -77,23 +77,30 @@ class Header(object):
 
     @property
     def data_type(self):
-        """A DataType object."""
+        """Get a DataType object."""
         return self._data_type
 
     @property
     def unit(self):
-        """A text string representing an abbreviated unit."""
+        """Get a text string representing an abbreviated unit (eg. 'C')."""
         return self._unit
 
     @property
     def analysis_period(self):
-        """A AnalysisPeriod object."""
+        """Get an AnalysisPeriod object."""
         return self._analysis_period
 
     @property
     def metadata(self):
-        """Dictionary of metadata associated with the Header."""
+        """Get or set a dictionary of metadata associated with the Header."""
         return self._metadata
+
+    @metadata.setter
+    def metadata(self, value):
+        if value is not None:
+            assert isinstance(value, dict), \
+                'Expected dictionary for Header metadata. Got {}.'.format(type(value))
+        self._metadata = value or {}
 
     def duplicate(self):
         """Return a copy of the header."""

--- a/tests/datatype_test.py
+++ b/tests/datatype_test.py
@@ -6,7 +6,7 @@ from ladybug.datatype import base
 from ladybug.datatype import angle, area, distance, energy, energyflux, \
     energyintensity, fraction, generic, illuminance, luminance, mass, massflowrate, \
     power, pressure, rvalue, speed, temperature, temperaturedelta, temperaturetime, \
-    thermalcondition, specificenergy, uvalue, volume, volumeflowrate
+    thermalcondition, time, specificenergy, uvalue, volume, volumeflowrate
 
 import pytest
 import math
@@ -515,6 +515,25 @@ def test_thermal_condition():
             assert len(tc_type.to_unit([1], other_unit, unit)) == 1
     assert tc_type.to_unit([1], 'PMV', 'condition')[0] == 1
     assert tc_type.to_unit([1], 'condition', 'PMV')[0] == 1
+
+
+def test_time():
+    """Test Time type."""
+    time_type = time.Time()
+    for unit in time_type.units:
+        assert time_type.to_unit([1], unit, unit)[0] == pytest.approx(1, rel=1e-5)
+        ip_vals, ip_u = time_type.to_ip([1], unit)
+        assert len(ip_vals) == 1
+        si_vals, si_u = time_type.to_si([1], unit)
+        assert len(si_vals) == 1
+        for other_unit in time_type.units:
+            assert len(time_type.to_unit([1], other_unit, unit)) == 1
+    assert time_type.to_unit([1], 'min', 'hr')[0] == 60
+    assert time_type.to_unit([1], 'sec', 'hr')[0] == 3600
+    assert time_type.to_unit([1], 'day', 'hr')[0] == 1 / 24.
+    assert time_type.to_unit([60], 'hr', 'min')[0] == 1.
+    assert time_type.to_unit([3600], 'hr', 'sec')[0] == 1.
+    assert time_type.to_unit([1], 'hr', 'day')[0] == 24.
 
 
 def test_specific_energy():


### PR DESCRIPTION
This is going to make certain post-processing work with datacollections of energy results so much cleaner.

I also fixed a bug in the Time data type thanks to tests that I added.

I also made the arithmetic operations with data collections duplicate the header such that any edits of that header's metadata don't edit the original.

Lastly, I made the metadata of the header set-able given that this doesn't break anything like how setting data types could break some things.