### PR TITLE
fix(windrose): Fix several issues RE: WindRose and LegendParameters

### DIFF
--- a/ladybug/windrose.py
+++ b/ladybug/windrose.py
@@ -262,14 +262,13 @@ class WindRose(object):
 
         Default segment count is 10.
         """
-        if self._legend_parameters is None:
-            self._legend_parameters = self.container.legend_parameters
-        return self._legend_parameters
+        return self.container.legend_parameters
 
     @legend_parameters.setter
     def legend_parameters(self, legend_parameters):
-        assert isinstance(legend_parameters, LegendParameters), 'legend_parameters' \
-            ' must be a LegendParameters. Got {}.'.format(type(legend_parameters))
+        if legend_parameters is not None:
+            assert isinstance(legend_parameters, LegendParameters), 'legend_parameters' \
+                ' must be a LegendParameters. Got {}.'.format(type(legend_parameters))
         self._compass = None
         self._container = None
         self._legend_parameters = legend_parameters
@@ -417,9 +416,7 @@ class WindRose(object):
         legend_parameters all influence the initiation of this object, this property
         is to None if any of those properties are edited by the user.
         """
-
         if self._container is None:
-
             # Get analysis values
             if self.show_freq:
                 values = [b for a in self.histogram_data for b in a]
@@ -436,8 +433,6 @@ class WindRose(object):
                 legend_parameters=self._legend_parameters,
                 data_type=self.analysis_data_collection.header.data_type,
                 unit=self.analysis_data_collection.header.unit)
-
-            self._container.legend_parameters.include_larger_smaller = True
         return self._container
 
     @property
@@ -470,7 +465,6 @@ class WindRose(object):
         # Calculate stacked_data
         flat_data = [b for a in self.histogram_data for b in a]
         max_data = max(flat_data)
-        print(flat_data)
         min_data = min(self.analysis_values) if self.show_zeros else min(flat_data)
         bin_count = self.legend_parameters.segment_count
         data_range = (min_data, max_data)
@@ -526,13 +520,10 @@ class WindRose(object):
         if isinstance(_l_par, LegendParametersCategorized):
             return ColorRange(_l_par.colors, _l_par.domain, _l_par.continuous_colors)
         else:
-            if (_l_par.min is None) or (_l_par.max is None):
-                values = self.container.values
-                if _l_par.min is None:
-                    _l_par.min = min(values)
-                if _l_par.max is None:
-                    _l_par.max = max(values)
-            return ColorRange(_l_par.colors, (_l_par.min, _l_par.max))
+            values = self.container.values
+            min_val = _l_par.min if _l_par.min is not None else min(values)
+            max_val = _l_par.max if _l_par.max is not None else max(values)
+            return ColorRange(_l_par.colors, (min_val, max_val))
 
     @property
     def orientation_lines(self):

--- a/tests/windrose_test.py
+++ b/tests/windrose_test.py
@@ -390,7 +390,7 @@ def test_windrose_set_legend_parameters():
     assert w.legend_parameters.segment_count == pytest.approx(16, abs=1e-10)
 
     # Check resetting
-    w._legend_parameters = None
+    w.legend_parameters = None
     assert isinstance(w.legend_parameters, LegendParameters)
     assert w.legend_parameters.segment_count == pytest.approx(11.0, abs=1e-10)
 
@@ -622,7 +622,7 @@ def test_color_array():
     w = WindRose(dir_data, spd_data, 4)
     w.show_freq, w.show_zeros = True, False
     w.frequency_hours = 2
-    w.legend_parameters.segment_count = 7
+    w.legend_parameters = LegendParameters(segment_count=7)
     w.colored_mesh
 
     # color index corresponds to hourly interval indices
@@ -646,7 +646,7 @@ def test_color_array():
     w = WindRose(zero_dir_data, zero_spd_data, 4)
     w.show_freq, w.show_zeros = True, True
     w.frequency_hours = 2
-    w.legend_parameters.segment_count = 7
+    w.legend_parameters = LegendParameters(segment_count=7)
     w.colored_mesh
 
     # color index corresponds to hourly interval indices
@@ -661,7 +661,7 @@ def test_color_array():
     w = WindRose(dir_data, spd_data, 4)
     w.show_freq, w.show_zeros = False, False
     w.frequency_hours = 2
-    w.legend_parameters.segment_count = 7
+    w.legend_parameters = LegendParameters(segment_count=7)
     w.colored_mesh
 
     # color index corresponds to hourly interval indices
@@ -674,7 +674,7 @@ def test_color_array():
     w = WindRose(dir_data, spd_data, 4)
     w.show_freq, w.show_zeros = False, True
     w.frequency_hours = 2
-    w.legend_parameters.segment_count = 7
+    w.legend_parameters = LegendParameters(segment_count=7)
     w.colored_mesh
 
     # color index corresponds to hourly interval indices
@@ -713,7 +713,7 @@ def test_wind_polygons():
     w = WindRose(dir_data, spd_data, 4)
     w.show_freq, w.show_zeros = True, False
     w.frequency_hours = 2
-    w.legend_parameters.segment_count = 6
+    w.legend_parameters = LegendParameters(segment_count=6)
 
     chk_poly_num = sum([3, 3, 1, 2])
     assert chk_poly_num == len(w.windrose_lines)


### PR DESCRIPTION
I realized there were some issues with the way that the wind rose was treating legend parameters. Notably, legend parameters are purely to manage user input and they should never be edited directly by a ladybug-core class. Otherwise, that class can end up mutating the legend parameters, which might be used by other objects.

Also, the wind rose should always default to returning the graphic container's parameters instead of its own.

Resolves https://github.com/ladybug-tools/ladybug/issues/377