### PR TITLE
fix(datacollection): Ensure type key always matches the collection type

### DIFF
--- a/ladybug/_datacollectionbase.py
+++ b/ladybug/_datacollectionbase.py
@@ -440,7 +440,7 @@ class BaseCollection(object):
             'values': self._values,
             'datetimes': self.datetimes,
             'validated_a_period': self._validated_a_period,
-            'type': 'BaseCollection'
+            'type': self.__class__.__name__
         }
 
     @staticmethod

--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -438,7 +438,7 @@ class HourlyDiscontinuousCollection(BaseCollection):
             'values': self._values,
             'datetimes': [dat.to_array() for dat in self.datetimes],
             'validated_a_period': self._validated_a_period,
-            'type': 'HourlyDiscontinuousCollection'
+            'type': self.__class__.__name__
         }
 
     def _xxrange(self, start, end, step_count):
@@ -920,7 +920,7 @@ class HourlyContinuousCollection(HourlyDiscontinuousCollection):
         return {
             'header': self.header.to_dict(),
             'values': self._values,
-            'type': 'HourlyContinuousCollection'
+            'type': self.__class__.__name__
         }
 
     def _get_analysis_period_subset(self, a_per):


### PR DESCRIPTION
I was getting cases of MonthlyCollections with BaseCollection type keys.