### PR TITLE
fix(datacollection): Allow MonthlyPerHour to support timesteps

### DIFF
--- a/ladybug/analysisperiod.py
+++ b/ladybug/analysisperiod.py
@@ -296,7 +296,10 @@ class AnalysisPeriod(object):
         month_hour = []
         hour_range = xrange(self.st_hour, (self.end_hour + 1) * self.timestep)
         for month in self.months_int:
-            month_hour.extend([(month, hr / self.timestep) for hr in hour_range])
+            month_hour.extend(
+                [(month, int(hr / self.timestep),
+                  int((hr % self.timestep) * (60 / self.timestep)))
+                 for hr in hour_range])
         return month_hour
 
     @property

--- a/ladybug/datacollection.py
+++ b/ladybug/datacollection.py
@@ -238,21 +238,23 @@ class HourlyDiscontinuousCollection(BaseCollection):
     def group_by_month_per_hour(self):
         """Return a dictionary of this collection's values grouped by each month per hour.
 
-        Key values are tuples of 2 integers.
+        Key values are tuples of 3 integers.
 
         -   The first represents the month of the year between 1-12.
 
         -   The second represents the hour of the day between 0-24.
-            (eg. (12, 23) for December at 11 PM)
+
+        -   The third represents the minute of the minute of the hour between 0-59.
         """
         t_step = self.header.analysis_period.timestep
         data_by_month_per_hour = OrderedDict()
         for m in xrange(1, 13):
             for h in xrange(0, 24 * t_step):
-                hr = h / t_step
-                data_by_month_per_hour[(m, hr)] = []
+                float_hr = h / t_step
+                hr, mi = int(float_hr), int((h % t_step) * (60 / t_step))
+                data_by_month_per_hour[(m, hr, mi)] = []
         for v, dt in zip(self.values, self.datetimes):
-            data_by_month_per_hour[(dt.month, dt.float_hour)].append(v)
+            data_by_month_per_hour[(dt.month, dt.hour, dt.minute)].append(v)
         return data_by_month_per_hour
 
     def average_monthly_per_hour(self):
@@ -1369,8 +1371,9 @@ class MonthlyPerHourCollection(BaseCollection):
             must have an AnalysisPeriod on it.
         values: A list of values.
         datetimes: A list of tuples that aligns with the list of values.
-            Each tuple should possess two values: the first is the month
-            and the second is the hour. (eg. (12, 23) = December at 11 PM)
+            Each tuple should possess three values: the first is the month, the
+            second is the hour, and the third is the minute. (eg. (12, 23, 30) =
+            December at 11:30 PM).
 
     Properties:
         * average
@@ -1422,8 +1425,9 @@ class MonthlyPerHourCollection(BaseCollection):
 
         Args:
            months_per_hour: A list of tuples representing months per hour.
-               Each tuple should possess two values: the first is the month
-               and the second is the hour. (eg. (12, 23) = December at 11 PM)
+               Each tuple should possess three values: the first is the month, the
+               second is the hour and the third is the minute. (eg. (12, 23, 30) =
+               December at 11:30 PM)
 
         Return:
             A new Data Collection with filtered data

--- a/tests/datacollection_test.py
+++ b/tests/datacollection_test.py
@@ -762,8 +762,8 @@ def test_filter_by_analysis_period_monthly_per_hour():
     filt_dc = dc.filter_by_analysis_period(a_per)
     assert len(filt_dc) == 2 * 24
     assert filt_dc.header.analysis_period == a_per
-    assert filt_dc.datetimes[0] == (3, 0)
-    assert filt_dc.datetimes[-1] == (4, 23)
+    assert filt_dc.datetimes[0] == (3, 0, 0)
+    assert filt_dc.datetimes[-1] == (4, 23, 0)
 
 
 def test_filter_by_analysis_period_continuous():
@@ -986,8 +986,8 @@ def test_average_monthly_per_hour():
     new_dc = dc.average_monthly_per_hour()
     assert isinstance(new_dc, MonthlyPerHourCollection)
     assert len(new_dc) == 12 * 24
-    assert new_dc.datetimes[0] == (1, 0)
-    assert new_dc.datetimes[-1] == (12, 23)
+    assert new_dc.datetimes[0] == (1, 0, 0)
+    assert new_dc.datetimes[-1] == (12, 23, 0)
     assert new_dc.is_continuous
     for i, val in enumerate(dc.group_by_month_per_hour().values()):
         assert new_dc[i] == sum(val) / len(val)
@@ -1001,8 +1001,8 @@ def test_total_monthly_per_hour():
     new_dc = dc.total_monthly_per_hour()
     assert isinstance(new_dc, MonthlyPerHourCollection)
     assert len(new_dc) == 12 * 24
-    assert new_dc.datetimes[0] == (1, 0)
-    assert new_dc.datetimes[-1] == (12, 23)
+    assert new_dc.datetimes[0] == (1, 0, 0)
+    assert new_dc.datetimes[-1] == (12, 23, 0)
     assert new_dc.is_continuous
     for i, val in enumerate(dc.group_by_month_per_hour().values()):
         assert new_dc[i] == sum(val)
@@ -1016,8 +1016,8 @@ def test_percentile_monthly_per_hour():
     new_dc = dc.percentile_monthly_per_hour(25)
     assert isinstance(new_dc, MonthlyPerHourCollection)
     assert len(new_dc) == 12 * 24
-    assert new_dc.datetimes[0] == (1, 0)
-    assert new_dc.datetimes[-1] == (12, 23)
+    assert new_dc.datetimes[0] == (1, 0, 0)
+    assert new_dc.datetimes[-1] == (12, 23, 0)
     assert new_dc.is_continuous
     pct_vals = list(xrange(24)) * 12
     for i, val in enumerate(pct_vals):


### PR DESCRIPTION
I realized that the current MonthlyPerHour collection could only handle timesteps of 1.  This commit fixes this such that finer timesteps are now acceptable.