### PR TITLE
feat(climatezone): Add module for computing climate zone classifications

### DIFF
--- a/ladybug/climatezone.py
+++ b/ladybug/climatezone.py
@@ -1,0 +1,82 @@
+# coding=utf-8
+"""Functions for computing climate classifications/zones from weather data."""
+from __future__ import division
+
+from .datacollection import HourlyContinuousCollection
+
+
+def ashrae_climate_zone(dry_bulb_temperature, annual_precipitation=None):
+    """Estimate the ASHRAE climate zone from a single year of dry bulb temperature.
+
+    Note:
+        [1] American Society of Heating Refrigerating and Air-Conditioning Engineers.
+        2010. ASHRAE 90.1-2010, Table B-4 International Climate Zone Definitions.
+
+    Args:
+        dry_bulb_temperature: A HourlyContinuousCollection of air temperature data,
+            typically coming from an EPW.
+        annual_precipitation: A number for the total annual liquid precipitation
+            depth in millimeters. This is used to determine whether the resulting
+            climate has the "dry" classification. If None, the climate will always
+            be assumed to be humid (type "A"), which tends to be more common than
+            the dry classification (type "B").
+    
+    Returns:
+        Text for the ASHRAE climate zone classification (eg. "4A").
+    """
+    # check the input dry_bulb_temperature
+    dbt = dry_bulb_temperature
+    assert isinstance(dbt, HourlyContinuousCollection), \
+        'Expected HourlyContinuousCollection for ashrae_climate_zone ' \
+        'dry_bulb_temperature. Got {}.'.format(type(dbt))
+    aper = dbt.header.analysis_period
+    assert aper.is_annual, 'ashrae_climate_zone dry_bulb_temperature must be annual.'
+    assert aper.timestep == 1, \
+        'ashrae_climate_zone dry_bulb_temperature must have a timestep of 1.'
+    if dbt.header.unit != 'C':
+        dbt = dbt.to_unit('C')
+    
+    # compute the number of heating and cooling degree days
+    cooling_deg_days, heating_deg_days = 0, 0
+    for t in dbt.values:
+        cdd = (t - 10) / 24 if t > 10 else 0
+        cooling_deg_days += cdd
+        hdd = (18 - t) / 24 if t < 18 else 0
+        heating_deg_days += hdd
+
+    # get the climate zone number from analysis of the degree days
+    potential_c, no_letter = False, False
+    if cooling_deg_days > 5000:
+        cz_number = '1'
+    elif cooling_deg_days > 3500:
+        cz_number = '2'
+    elif cooling_deg_days > 2500:
+        cz_number = '3'
+    elif cooling_deg_days <= 2500 and heating_deg_days <= 2000:
+        cz_number, potential_c = '3', True
+    elif cooling_deg_days <= 2500 and heating_deg_days <= 3000:
+        cz_number = '4'
+    elif heating_deg_days <= 3000:
+        cz_number, potential_c = '4', True
+    elif heating_deg_days <= 4000:
+        cz_number, potential_c = '5', True
+    elif heating_deg_days <= 5000:
+        cz_number = '6'
+    elif heating_deg_days <= 7000:
+        cz_number, no_letter = '7', True
+    else:
+        cz_number, no_letter = '8', True
+
+    # determine the letter of the climate zone and return the result
+    if no_letter:
+        return cz_number
+    if potential_c:
+        month_temps = dry_bulb_temperature.average_monthly()
+        if -3 < month_temps.min < 18 and month_temps.max < 22:
+            if len([mon for mon in month_temps if mon > 10]) >= 4:
+                return '{}C'.format(cz_number)
+    if annual_precipitation is not None:
+        precipitation_limit = 20 * (dry_bulb_temperature.average + 7)
+        if annual_precipitation < precipitation_limit:
+            return '{}B'.format(cz_number)
+    return '{}A'.format(cz_number)

--- a/ladybug/epw.py
+++ b/ladybug/epw.py
@@ -14,6 +14,7 @@ from .ddy import DDY
 from .futil import write_to_file
 from .header import Header
 from .location import Location
+from .climatezone import ashrae_climate_zone
 from .skymodel import calc_sky_temperature
 from .psychrometrics import rel_humid_from_db_dpt, wet_bulb_from_db_rh
 
@@ -43,6 +44,7 @@ class EPW(object):
         * extreme_hot_weeks
         * extreme_cold_weeks
         * typical_weeks
+        * ashrae_climate_zone
         * monthly_ground_temperature
         * header
 
@@ -466,6 +468,17 @@ class EPW(object):
         self._load_header_check()
         self._weeks_check(data, 'typical_weeks')
         self._typical_weeks = data
+
+    @property
+    def ashrae_climate_zone(self):
+        """Text for the ASHRAE climate zone, estimated from the dry bulb temperature.
+
+        Note that all climate zones that should have a "B" will have an "A" for
+        this property because EPW files almost never have correct precipitation
+        data. If accurate precipitation data is available from another source, the
+        ashrae_climate_zone method in the climatezone module should be used instead.
+        """
+        return ashrae_climate_zone(self.dry_bulb_temperature)
 
     @property
     def monthly_ground_temperature(self):

--- a/tests/epw_test.py
+++ b/tests/epw_test.py
@@ -26,6 +26,7 @@ def test_import_epw():
     assert epw.is_data_loaded
     assert len(dbt) == 8760
     assert len(skyt) == 8760
+    assert epw.ashrae_climate_zone == '5A'
 
 
 def test_import_tokyo_epw():
@@ -39,6 +40,7 @@ def test_import_tokyo_epw():
     dbt = epw.dry_bulb_temperature
     assert epw.is_data_loaded
     assert len(dbt) == 8760
+    assert epw.ashrae_climate_zone == '3A'
 
 
 def test_epw_from_missing_values():


### PR DESCRIPTION
This is going to be extremely helpful for the case that the STAT file doesn't have any climate zone data. Now, people will be able to get the right climate zone number so that they can pick a good default construction set for their energy models.