### PR TITLE
fix(cli): Replace hacky use of analysis period JSON with string

### DIFF
--- a/ladybug/analysisperiod.py
+++ b/ladybug/analysisperiod.py
@@ -64,7 +64,6 @@ class AnalysisPeriod(object):
         '_timestamps_data', '_datetimes'
     )
 
-    # TODO: handle timestep between 1-60
     def __init__(self, st_month=1, st_day=1, st_hour=0, end_month=12,
                  end_day=31, end_hour=23, timestep=1, is_leap_year=False):
         """Init an analysis period.

--- a/ladybug/cli/_helper.py
+++ b/ladybug/cli/_helper.py
@@ -7,13 +7,11 @@ import json
 from ladybug.analysisperiod import AnalysisPeriod
 
 
-def _load_analysis_period_json(analysis_period_json):
+def _load_analysis_period_str(analysis_period_str):
     """Load an AnalysisPeriod from a JSON file.
     
     Args:
-        analysis_period_json: A JSON file of an AnalysisPeriod to be loaded.
+        analysis_period_str: A JSON file of an AnalysisPeriod to be loaded.
     """
-    if analysis_period_json is not None and analysis_period_json != 'None':
-        with open(analysis_period_json) as json_file:
-            data = json.load(json_file)
-        return AnalysisPeriod.from_dict(data)
+    if analysis_period_str is not None and analysis_period_str != 'None':
+        return AnalysisPeriod.from_string(analysis_period_str)

--- a/ladybug/cli/translate.py
+++ b/ladybug/cli/translate.py
@@ -7,7 +7,7 @@ from ladybug.wea import Wea
 from ladybug.ddy import DDY
 from ladybug.epw import EPW
 
-from ._helper import _load_analysis_period_json
+from ._helper import _load_analysis_period_str
 
 _logger = logging.getLogger(__name__)
 
@@ -20,9 +20,9 @@ def translate():
 @translate.command('epw-to-wea')
 @click.argument('epw-file', type=click.Path(
     exists=True, file_okay=True, dir_okay=False, resolve_path=True))
-@click.option('--analysis-period', '-ap', help='An AnalysisPeriod JSON to filter '
-              'the datetimes in the resulting Wea. If unspecified, the Wea will '
-              'be annual.', default=None, type=str)
+@click.option('--analysis-period', '-ap', help='An AnalysisPeriod string to filter the '
+              'datetimes in the resulting Wea (eg. "6/21 to 9/21 between 8 and 16 @1"). '
+              'If unspecified, the Wea will be annual.', default=None, type=str)
 @click.option('--timestep', '-t', help='An optional integer to set the number of '
               'time steps per hour. Default is 1 for one value per hour. Note that '
               'this input will only do a linear interpolation over the data in the EPW '
@@ -39,7 +39,7 @@ def epw_to_wea(epw_file, analysis_period, timestep, output_file):
     """
     try:
         wea_obj = Wea.from_epw_file(epw_file, timestep)
-        analysis_period = _load_analysis_period_json(analysis_period)
+        analysis_period = _load_analysis_period_str(analysis_period)
         if analysis_period is not None:
             wea_obj = wea_obj.filter_by_analysis_period(analysis_period)
         output_file.write(wea_obj.to_file_string())

--- a/tests/cli_translate_test.py
+++ b/tests/cli_translate_test.py
@@ -1,8 +1,11 @@
 """Test cli translate module."""
 from click.testing import CliRunner
-from ladybug.cli.translate import epw_to_wea, epw_to_ddy
-
 import os
+
+from ladybug.cli.translate import epw_to_wea, epw_to_ddy
+from ladybug.analysisperiod import AnalysisPeriod
+
+
 
 
 def test_epw_to_wea():
@@ -17,6 +20,15 @@ def test_epw_to_wea():
     assert result.exit_code == 0
     assert os.path.isfile(output_wea)
     os.remove(output_wea)
+
+
+def test_epw_to_wea_analysis_period():
+    runner = CliRunner()
+    input_epw = './tests/fixtures/epw/chicago.epw'
+
+    a_per = AnalysisPeriod(6, 21, 8, 9, 21, 17)
+    result = runner.invoke(epw_to_wea, [input_epw, '--analysis-period', str(a_per)])
+    assert result.exit_code == 0
 
 
 def test_epw_to_ddy():


### PR DESCRIPTION
I realized that the AnalysisPeriod object already has all of its properties within its string representation. So just having people pass a string of an analysis period to the CLI will be much cleaner. And it allows us to get around the fact that queenbee does not support conditional artifacts.