### PR TITLE
fix(epw): Fixed a bug in the EPW.to_wea header

### DIFF
--- a/ladybug/epw.py
+++ b/ladybug/epw.py
@@ -1443,7 +1443,7 @@ climate-calculations.html#energyplus-sky-temperature-calculation
             "longitude %.2f\n" % -self.location.longitude + \
             "time_zone %d\n" % (-self.location.time_zone * 15) + \
             "site_elevation %.1f\n" % self.location.elevation + \
-            "weather_data_file_unit 1\n"
+            "weather_data_file_units 1\n"
 
     def to_dict(self):
         """Convert the EPW to a dictionary."""


### PR DESCRIPTION
The term for "weather_data_file_units" is being written out as "weather_data_file_unit". This causes dctimestep to raise an error.

Before the fix: 
![2021-12-21 15_49_15-D__Seattle wea - Notepad++](https://user-images.githubusercontent.com/91887472/146949724-2cae01be-c8a5-4c8d-9dd9-ea4c973410f2.png)

After the fix:
![2021-12-21 15_49_36-D__Seattle wea - Notepad++](https://user-images.githubusercontent.com/91887472/146949786-6723c338-3841-4a2f-a183-42eba5041fd8.png)

