### PR TITLE
Bumped click version to 8.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 ladybug-geometry==1.25.4
-click==7.1.2
+click==8.1.3


### PR DESCRIPTION
This PR updates click to version 8.1.3.

This will allow auto formatting using Black, which has click 8+ as a dependency (See this [issue in black repo](https://github.com/psf/black/issues/3111))

All tests pass.
Please let me know if there is any other validation required before merging this change.

Thanks! 🐞

