### PR TITLE
fix(config): Check for home folder during init

### DIFF
--- a/ladybug/config.py
+++ b/ladybug/config.py
@@ -262,7 +262,8 @@ class Folders(object):
                 install_folder = os.path.join(program_folder, 'ladybug_tools')
             else:
                 try:
-                    os.makedirs(install_folder)
+                    if not os.path.isdir(install_folder):
+                        os.makedirs(install_folder)
                 except Exception as e:
                     # very rare case of an inaccessible HOME folder
                     # try to fall back on the Python installation folder of this package


### PR DESCRIPTION
Adds a check to [config.py | Folders._find_default_ladybug_tools_folder()](https://github.com/ladybug-tools/ladybug/blob/25f88a22b1ca9adfa2ad6ee77711746ff6b12361/ladybug/config.py#L251) method to ensure that if the 'ladybug_tools' folder already exists on the user's computer, we don't try and create it again (which would raise an OS Error / WinError 183)

- See discussion here [link](https://3.basecamp.com/4298486/buckets/24461086/messages/6106616191) for background on the issue.

- All existing tests pass, but I did know how to add new tests for this without editing folders on the user's computer, which did not seem like the right path?