### PR TITLE
fix(deps): bump click from 8.1.3 to 8.1.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ladybug-geometry==1.32.5
 click==7.1.2;python_version<'3.8'
-click==8.1.3;python_version>='3.8'
+click==8.1.7;python_version>='3.8'


### PR DESCRIPTION
This change makes Ladybug Tools compatible with Pyodide and py.cafe. currently this requirement creates conflict between the two.