### PR TITLE
Add equidistant and equisolid projection methods

### DIFF
--- a/ladybug/compass.py
+++ b/ladybug/compass.py
@@ -13,9 +13,9 @@ import math
 class Compass(object):
     """Object for computing geometry for the compass used by a variety of graphics.
 
-    Methods to project points to orthographic and stereographic projections are
-    also within this class so that "domed" visualizations can be synchronized with
-    the compass in the 2D plane.
+    Methods to project points to orthographic, stereographic, equidistant, and
+    equisolid projections are also within this class so that "domed"
+    visualizations can be synchronized with the compass in the 2D plane.
 
     Args:
         radius: A positive number for the radius of the compass. (Default: 100).
@@ -262,6 +262,59 @@ class Compass(object):
                 stereographic projection.
         """
         return Point2D(point.x, point.y)
+
+    @staticmethod
+    def point3d_to_equidistant(point, radius=100, origin=Point3D()):
+        """Get a Point2D for a given Point3D using an equidistant projection.
+
+        Args:
+            point: A ladybug_geometry Point3D to be projected into 2D space via
+                equidistant projection.
+            radius: A positive number for the radius of the sphere on which the
+                point exists. (Default: 100).
+            origin: An optional ladybug_geometry Point3D representing the origin
+                of the coordinate system in which the projection is happening.
+                (eg. the center of the compass).
+        """
+        # move the point to the world origin
+        coords = ((point.x - origin.x), (point.y - origin.y), (point.z - origin.z))
+        dist_xy = math.sqrt(coords[0] ** 2 + coords[1] ** 2)
+        if dist_xy == 0:
+            return Point2D(origin.x, origin.y)
+
+        z_ratio = coords[2] / radius
+        z_ratio = min(1, max(-1, z_ratio))
+        zenith_angle = math.acos(z_ratio)
+        proj_radius = radius * ((2 * zenith_angle) / math.pi)
+        scale = proj_radius / dist_xy
+        return Point2D(coords[0] * scale + origin.x, coords[1] * scale + origin.y)
+
+    @staticmethod
+    def point3d_to_equisolid(point, radius=100, origin=Point3D()):
+        """Get a Point2D for a given Point3D using an equisolid projection.
+
+        Args:
+            point: A ladybug_geometry Point3D to be projected into 2D space via
+                equisolid projection.
+            radius: A positive number for the radius of the sphere on which the
+                point exists. (Default: 100).
+            origin: An optional ladybug_geometry Point3D representing the origin
+                of the coordinate system in which the projection is happening.
+                (eg. the center of the compass).
+        """
+        # move the point to the world origin
+        coords = ((point.x - origin.x), (point.y - origin.y), (point.z - origin.z))
+        dist_xy = math.sqrt(coords[0] ** 2 + coords[1] ** 2)
+        if dist_xy == 0:
+            return Point2D(origin.x, origin.y)
+
+        z_ratio = coords[2] / radius
+        z_ratio = min(1, max(-1, z_ratio))
+        zenith_angle = math.acos(z_ratio)
+        proj_radius = radius * (
+            math.sin(zenith_angle / 2) / math.sin(math.pi / 4))
+        scale = proj_radius / dist_xy
+        return Point2D(coords[0] * scale + origin.x, coords[1] * scale + origin.y)
 
     @staticmethod
     def point3d_to_stereographic(point, radius=100, origin=Point3D()):

--- a/tests/compass_test.py
+++ b/tests/compass_test.py
@@ -1,4 +1,6 @@
 # coding=utf-8
+import math
+
 from ladybug.compass import Compass
 
 from ladybug_geometry.geometry2d.pointvector import Point2D, Vector2D
@@ -62,6 +64,58 @@ def test_compass_stereographic():
     assert len(compass.stereographic_altitude_circles) == len(compass.ALTITUDES)
     for lin in compass.stereographic_altitude_circles:
         assert isinstance(lin, Arc2D)
+
+
+def test_point3d_to_equidistant():
+    """Test the equidistant projection of 3D points to a 2D plane."""
+    assert Compass.point3d_to_equidistant(Point3D(0, 0, 100)).is_equivalent(
+        Point2D(0, 0), 0.01)
+    assert Compass.point3d_to_equidistant(Point3D(100, 0, 0)).is_equivalent(
+        Point2D(100, 0), 0.01)
+    assert Compass.point3d_to_equidistant(Point3D(0, 100, 0)).is_equivalent(
+        Point2D(0, 100), 0.01)
+
+    half_radius = math.sqrt(0.5) * 100
+    assert Compass.point3d_to_equidistant(
+        Point3D(half_radius, 0, half_radius)).is_equivalent(
+            Point2D(50, 0), 0.01)
+
+    origin = Point3D(10, 20, 30)
+    assert Compass.point3d_to_equidistant(
+        Point3D(110, 20, 30), origin=origin).is_equivalent(
+            Point2D(110, 20), 0.01)
+    half_large_radius = math.sqrt(0.5) * 200
+    assert Compass.point3d_to_equidistant(
+        Point3D(0, half_large_radius, half_large_radius), radius=200).is_equivalent(
+            Point2D(0, 100), 0.01)
+
+
+def test_point3d_to_equisolid():
+    """Test the equisolid projection of 3D points to a 2D plane."""
+    assert Compass.point3d_to_equisolid(Point3D(0, 0, 100)).is_equivalent(
+        Point2D(0, 0), 0.01)
+    assert Compass.point3d_to_equisolid(Point3D(100, 0, 0)).is_equivalent(
+        Point2D(100, 0), 0.01)
+    assert Compass.point3d_to_equisolid(Point3D(0, 100, 0)).is_equivalent(
+        Point2D(0, 100), 0.01)
+
+    half_radius = math.sqrt(0.5) * 100
+    expected_radius = \
+        100 * math.sin(math.radians(45) / 2) / math.sin(math.pi / 4)
+    assert Compass.point3d_to_equisolid(
+        Point3D(half_radius, 0, half_radius)).is_equivalent(
+            Point2D(expected_radius, 0), 0.01)
+
+    origin = Point3D(10, 20, 30)
+    assert Compass.point3d_to_equisolid(
+        Point3D(110, 20, 30), origin=origin).is_equivalent(
+            Point2D(110, 20), 0.01)
+    half_large_radius = math.sqrt(0.5) * 200
+    expected_large_radius = \
+        200 * math.sin(math.radians(45) / 2) / math.sin(math.pi / 4)
+    assert Compass.point3d_to_equisolid(
+        Point3D(0, half_large_radius, half_large_radius), radius=200).is_equivalent(
+            Point2D(0, expected_large_radius), 0.01)
 
 
 def test_set_properties():


### PR DESCRIPTION
## Summary

This PR adds two additional sky-dome projection helpers to `Compass`:

- `point3d_to_equidistant`
- `point3d_to_equisolid`

Both methods keep the same compass convention used by the existing projection helpers, with the horizon mapping to the compass radius.

## Context

This follows the projection discussion from the Ladybug Tools forum:

https://discourse.ladybug.tools/t/equidistant-projection-for-lb-skymask-and-sunpath/40387/2

## Validation

- `python -m pytest` -> 420 passed